### PR TITLE
Add linux gomp and post link to screened poisson

### DIFF
--- a/src/meshlabplugins/filter_screened_poisson/filter_screened_poisson.pro
+++ b/src/meshlabplugins/filter_screened_poisson/filter_screened_poisson.pro
@@ -2,6 +2,7 @@ include (../../shared.pri)
 
 macx:QMAKE_CXX = clang++-mp-3.9
 macx:QMAKE_LFLAGS += -L/opt/local/lib/libomp -lomp
+linux:QMAKE_LFLAGS += -lgomp
 macx:QMAKE_CXXFLAGS_RELEASE+= -O3 -DRELEASE -funroll-loops -ffast-math  -Wno-sign-compare -Wno-unused-parameter
 
 QMAKE_CXXFLAGS+=-fopenmp
@@ -22,4 +23,4 @@ DEFINES += FOR_RELEASE
 
 #PRE_TARGETDEPS += ./filter_screened_poisson.xml
 macx:QMAKE_POST_LINK = "cp "$$_PRO_FILE_PWD_/$$TARGET".xml ../../distrib/plugins/"$$TARGET".xml"
-
+linux:QMAKE_POST_LINK = "cp "$$_PRO_FILE_PWD_/$$TARGET".xml ../../distrib/plugins/"$$TARGET".xml; cd ../../distrib/plugins/ ; ln -s "$$TARGET".xml lib"$$TARGET".xml"

--- a/src/meshlabplugins/filter_screened_poisson/filter_screened_poisson.pro
+++ b/src/meshlabplugins/filter_screened_poisson/filter_screened_poisson.pro
@@ -2,7 +2,7 @@ include (../../shared.pri)
 
 macx:QMAKE_CXX = clang++-mp-3.9
 macx:QMAKE_LFLAGS += -L/opt/local/lib/libomp -lomp
-linux:QMAKE_LFLAGS += -lgomp
+linux:QMAKE_LFLAGS += -fopenmp -lgomp
 macx:QMAKE_CXXFLAGS_RELEASE+= -O3 -DRELEASE -funroll-loops -ffast-math  -Wno-sign-compare -Wno-unused-parameter
 
 QMAKE_CXXFLAGS+=-fopenmp


### PR DESCRIPTION
The project file for screened poisson is lacking linux linker flag -lgomp and post link filter_screened_poisson.xml copying script.
_The libfilter_screened_poisson.xml link is somehow needed for plugin manager to work correctly on linux (`help>about_plugins` menu is empty for screened_poisson plugin without it)_
_mutualinfo, measure, and sketchfab plugins share this problem too_