### PR TITLE
UI: hide memory bar if memory info is not available

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -2494,6 +2494,7 @@ void MainWindow::updateGPUMemBar(int allmem,int currentallocated)
 {
     if (nvgpumeminfo != NULL)
     {
+        nvgpumeminfo->setVisible(allmem != 0);
         nvgpumeminfo->setFormat( "Mem %p% %v/%m MB" );
         int allmb = allmem/1024;
         nvgpumeminfo->setRange(  0 , allmb );


### PR DESCRIPTION
Hide the memory info bar if the OpenGL implementation doesn't support
returning the GL memory information. Otherwise, the progress bar would
be shown as spinning the whole time.