### PR TITLE
Set vcglib as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vcglib"]
+	path = vcglib
+	url = https://github.com/cnr-isti-vclab/vcglib.git
+	branch = devel

--- a/src/general.pri
+++ b/src/general.pri
@@ -5,7 +5,7 @@
 # it can be double or float according to user needs.
 DEFINES += MESHLAB_SCALAR=float
 
-VCGDIR   = ../../../vcglib
+VCGDIR   = ../../vcglib
 EIGENDIR = $$VCGDIR/eigenlib
 GLEWDIR = ../external/glew-1.7.0
 


### PR DESCRIPTION
Fixes #5 .
Path to vcglib submodule can be moved, let me know.