### PR TITLE
Solves Snap All Layers crash if snapshot is taken after removal of mesh

### DIFF
--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -979,7 +979,7 @@ void GLArea::saveSnapshot()
         {
             tileRow=tileCol=0;
             qDebug("Snapping layer %i",currSnapLayer);
-            this->md()->setCurrentMesh(currSnapLayer);
+            this->md()->setCurrentMesh(this->md()->meshList.at(currSnapLayer)->id());
             foreach(MeshModel *mp,this->md()->meshList) {
                 meshSetVisibility(mp,false);
             }


### PR DESCRIPTION
Solves #263. In GLArea::saveSnapshot(), currentMesh was initialized by ID, even in the case that the mesh referenced by ID was deleted.