### PR TITLE
Add missing Qt includes

### DIFF
--- a/src/meshlabplugins/edit_paint/paintbox.cpp
+++ b/src/meshlabplugins/edit_paint/paintbox.cpp
@@ -23,6 +23,7 @@
 
 #include "paintbox.h"
 #include <QFileDialog>
+#include <QAction>
 
 Paintbox::Paintbox(QWidget * parent, Qt::WindowFlags flags) : QWidget(parent, flags)
 {

--- a/src/meshlabplugins/render_gdp/shaderDialog.h
+++ b/src/meshlabplugins/render_gdp/shaderDialog.h
@@ -32,6 +32,8 @@
 #include "shaderStructs.h"
 #include "ui_shaderDialog.h"
 #include <QMap>
+#include <QLineEdit>
+#include <QSlider>
 
 class QGLWidget;
 


### PR DESCRIPTION
    shaderDialog.h:55:21: error: 'QSlider' was not declared in this scope
    shaderDialog.h:56:15: error: 'QLineEdit' was not declared in this scope
    paintbox.cpp:35:30: error: invalid use of incomplete type 'class QAction'
    ...