### PR TITLE
Fix meshlabserver rpath for mac

### DIFF
--- a/src/general.pri
+++ b/src/general.pri
@@ -20,6 +20,10 @@ macx:CONFIG(debug, debug|release):QMAKE_CXXFLAGS += -O0 -g
 macx:QMAKE_CXX = /opt/local/bin/clang++-mp-6.0
 macx:QMAKE_CXXFLAGS += -fopenmp
 macx:QMAKE_LFLAGS += -L/opt/local/lib/libomp -lomp
+macx:{
+  QMAKE_LFLAGS_RPATH=
+  QMAKE_LFLAGS += "-Wl,-rpath,@executable_path/../Frameworks"
+}
 
 
 MACLIBDIR = ../../external/lib/macx64

--- a/src/install/macx/macinstall_v2016.sh
+++ b/src/install/macx/macinstall_v2016.sh
@@ -48,10 +48,15 @@ do
 cp ./$x $BUNDLE/meshlab.app/Contents/PlugIns/
 done
 
-for x in $BUNDLE/meshlab.app/Contents/plugins/*.dylib
+for x in $BUNDLE/meshlab.app/Contents/PlugIns/*.dylib
 do
  install_name_tool -change libcommon.1.dylib @executable_path/libcommon.1.dylib $x
 done
+
+MESHLABSERVER_PATH=$BUNDLE/meshlab.app/Contents/MacOS/meshlabserver
+install_name_tool -rpath "/Users/cignoni/Qt/5.7/clang_64/lib" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
+  install_name_tool -rpath "@executable_path/Frameworks" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
+  install_name_tool -add_rpath "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null
 
 echo 'Copying samples and other files'
 

--- a/src/install/macx/macinstall_v2016.sh
+++ b/src/install/macx/macinstall_v2016.sh
@@ -53,11 +53,6 @@ do
  install_name_tool -change libcommon.1.dylib @executable_path/libcommon.1.dylib $x
 done
 
-MESHLABSERVER_PATH=$BUNDLE/meshlab.app/Contents/MacOS/meshlabserver
-install_name_tool -rpath "/Users/cignoni/Qt/5.7/clang_64/lib" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
-  install_name_tool -rpath "@executable_path/Frameworks" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
-  install_name_tool -add_rpath "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null
-
 echo 'Copying samples and other files'
 
 cp ../../LICENSE.txt $BUNDLE

--- a/src/install/macx/macinstall_v2018.sh
+++ b/src/install/macx/macinstall_v2018.sh
@@ -70,11 +70,6 @@ do
  install_name_tool -change libcommon.1.dylib @executable_path/libcommon.1.dylib $x
 done
 
-MESHLABSERVER_PATH=$BUNDLE/meshlab.app/Contents/MacOS/meshlabserver
-install_name_tool -rpath "/Users/cignoni/Qt/5.7/clang_64/lib" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
-  install_name_tool -rpath "@executable_path/Frameworks" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
-  install_name_tool -add_rpath "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null
-
 echo 'Copying samples and other files'
 
 cp ../../LICENSE.txt $BUNDLE

--- a/src/install/macx/macinstall_v2018.sh
+++ b/src/install/macx/macinstall_v2018.sh
@@ -65,10 +65,15 @@ do
 cp ./$x $BUNDLE/meshlab.app/Contents/PlugIns/
 done
 
-for x in $BUNDLE/meshlab.app/Contents/plugins/*.dylib
+for x in $BUNDLE/meshlab.app/Contents/PlugIns/*.dylib
 do
  install_name_tool -change libcommon.1.dylib @executable_path/libcommon.1.dylib $x
 done
+
+MESHLABSERVER_PATH=$BUNDLE/meshlab.app/Contents/MacOS/meshlabserver
+install_name_tool -rpath "/Users/cignoni/Qt/5.7/clang_64/lib" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
+  install_name_tool -rpath "@executable_path/Frameworks" "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null || \
+  install_name_tool -add_rpath "@executable_path/../Frameworks" $MESHLABSERVER_PATH 2>/dev/null
 
 echo 'Copying samples and other files'
 


### PR DESCRIPTION
Fix meshlabserver on mac to set proper `@rpath`.

It looks the path of `LC_RPATH` (`@rpath`) in meshlabserver differs from release to release..(changing it such as `/Users/cignoni/Qt/5.7/clang_64/lib` and `@executable_path/Frameworks`..)
It depends on the environments where the build's done due to a default RPATH used. I fixed it specifying the RPATH to `@executable_path/../Frameworks` on mac by editing general.pri.

#64 