### PR TITLE
fix meshlabserver issue 357

### DIFF
--- a/src/meshlabserver/mainserver.cpp
+++ b/src/meshlabserver/mainserver.cpp
@@ -158,6 +158,7 @@ public:
 
         RichParameterSet prePar;
         pCurrentIOPlugin->initPreOpenParameter(extension, fileName,prePar);
+		prePar.join(defaultGlobal);
 
         if (!pCurrentIOPlugin->open(extension, fileName, mm ,mask,prePar))
         {


### PR DESCRIPTION
This change is consistent with UI when load plugins. It ensures the following codes to be executed:
		RichParameter* stlunif = parlst.findParameter(stlUnifyParName());
		if ((stlunif != NULL) && (stlunif->val->getBool()))
		{
			tri::Clean<CMeshO>::RemoveDuplicateVertex(m.cm);
			tri::Allocator<CMeshO>::CompactEveryVector(m.cm);
		}
