### PR TITLE
Retry matching of labels to actions after stripping spurious accelera…

### DIFF
--- a/src/common/interfaces.h
+++ b/src/common/interfaces.h
@@ -364,9 +364,12 @@ public:
 
 	virtual FilterIDType ID(QAction *a) const
 	{
+	QString aa=a->text();
 		foreach(FilterIDType tt, types())
 			if (a->text() == this->filterName(tt)) return tt;
-
+		aa.replace("&","");
+		foreach(FilterIDType tt, types())
+			if (aa == this->filterName(tt)) return tt;
 
 		qDebug("unable to find the id corresponding to action  '%s'", qUtf8Printable(a->text()));
 		assert(0);
@@ -381,9 +384,13 @@ public:
 
 	virtual QAction *AC(QString idName)
 	{
+	QString i=idName;
 		foreach(QAction *tt, actionList)
 			if (idName == tt->text()) return tt;
-
+		i.replace("&","");
+		foreach(QAction *tt, actionList)
+			if (i == tt->text()) return tt;
+		
 		qDebug("unable to find the action corresponding to action  '%s'", qUtf8Printable(idName));
 		assert(0);
 		return 0;
@@ -521,16 +528,26 @@ protected:
 	QList <FilterIDType> typeList;
 	virtual FilterIDType ID(QAction *a) const
 	{
+		QString aa=a->text();
 		foreach(FilterIDType tt, types())
 			if (a->text() == this->decorationName(tt)) return tt;
+		aa.replace("&","");
+		foreach(FilterIDType tt, types())
+			if (aa == this->decorationName(tt)) return tt;
+
 		qDebug("unable to find the id corresponding to action  '%s'", qUtf8Printable(a->text()));
 		assert(0);
 		return -1;
 	}
 	virtual FilterIDType ID(QString name) const
 	{
+		QString n = name;
 		foreach(FilterIDType tt, types())
 			if (name == this->decorationName(tt)) return tt;
+		n.replace("&","");
+		foreach(FilterIDType tt, types())
+			if (n == this->decorationName(tt)) return tt;
+
 		qDebug("unable to find the id corresponding to action  '%s'", qUtf8Printable(name));
 		assert(0);
 		return -1;
@@ -538,8 +555,13 @@ protected:
 public:
 	virtual QAction *action(QString name) const
 	{
+		QString n = name;
 		foreach(QAction *tt, actions())
 			if (name == this->decorationName(ID(tt))) return tt;
+		n.replace("&","");
+		foreach(QAction *tt, actions())
+			if (n == this->decorationName(ID(tt))) return tt;
+
 		qDebug("unable to find the id corresponding to action  '%s'", qUtf8Printable(name));
 		return 0;
 	}

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -1171,6 +1171,7 @@ void MainWindow::startFilter()
         {
             MeshLabFilterInterface *iXMLFilter = qobject_cast<MeshLabFilterInterface *>(action->parent());
             QString fname = action->text();
+            fname.replace("&","");
             MeshLabXMLFilterContainer& filt  = PM.stringXMLFilterMap[fname];
 
             if ((iXMLFilter == NULL) || (filt.xmlInfo == NULL) || (filt.act == NULL))
@@ -1744,6 +1745,7 @@ void MainWindow::executeFilter(MeshLabXMLFilterContainer* mfc,const QMap<QString
         throw MLException("A not-C++ and not-JaveScript filter has been invoked.There is something really wrong in MeshLab.");
 
     QString fname = mfc->act->text();
+    fname.replace("&","");
     QString postCond = mfc->xmlInfo->filterAttribute(fname,MLXMLElNames::filterPostCond);
     QStringList postCondList = postCond.split(QRegExp("\\W+"), QString::SkipEmptyParts);
     int postCondMask = MeshLabFilterInterface::convertStringListToMeshElementEnum(postCondList);
@@ -1883,6 +1885,7 @@ void MainWindow::postFilterExecution()
     if (mfc == PM.stringXMLFilterMap.constEnd())
         return;
     QString fname = mfc->act->text();
+    fname.replace("&","");
     // at the end for filters that change the color, or selection set the appropriate rendering mode
     QString filterClasses = mfc->xmlInfo->filterAttribute(fname,MLXMLElNames::filterClass);
     QStringList filterClassesList = filterClasses.split(QRegExp("\\W+"), QString::SkipEmptyParts);


### PR DESCRIPTION
…tors

A component of the KDE5 desktop environment injects ampersand characters into the labels of any Qt-based application that does not provide its own accelerator keys, which breaks the matching of menu items to actions. With this patch, matching is retried after stripping any amperand characters.
Fixes #180 and #296 