### PR TITLE
Fixed texture deallocation

### DIFF
--- a/src/common/ml_shared_data_context.cpp
+++ b/src/common/ml_shared_data_context.cpp
@@ -106,13 +106,17 @@ void MLSceneGLSharedDataContext::deAllocateTexturesPerMesh( int mmid )
     if (man != NULL)
     {
         QGLContext* ctx = makeCurrentGLContext();
+        std::vector<GLuint> texids;
         for(size_t ii = 0;ii < man->textureIDContainer().size();++ii)
         {
-            GLuint textid = man->textureIDContainer().remove(man->textureIDContainer()[ii]);
-            glDeleteTextures(1,&textid);
+            texids.push_back(man->textureIDContainer()[ii]);
         }
-        doneCurrentGLContext(ctx);
 
+        for (auto tex : texids)
+            man->textureIDContainer().remove(tex);
+
+        glDeleteTextures(texids.size(), texids.data());
+        doneCurrentGLContext(ctx);
     }
 }
 


### PR DESCRIPTION
Fixes wrong texture deallocation on mesh layers with multiple textures (to see the issue just load a mesh with more than one texture and then press the reload button).