### PR TITLE
filter_mls: fixed crash due to deleting a `MlsSurface *` which couldn't

### DIFF
--- a/src/meshlabplugins/filter_mls/mlssurface.h
+++ b/src/meshlabplugins/filter_mls/mlssurface.h
@@ -78,6 +78,8 @@ class MlsSurface
             mDomainNormalScale = 1.;
         }
 
+        virtual ~MlsSurface() {}
+
         /** \returns the value of the reconstructed scalar field at point \a x */
         virtual Scalar potential(const VectorType& x, int* errorMask = 0) const = 0;
 


### PR DESCRIPTION
`MlsSurface` is an abstract class whose destructor (as well as its constructor) cannot be called directly.
It can be called only on its derived non-abstract classes. Calling `delete` on a pointer of type `MlsSurface *`, pointing to a concrete class (either RIMLS or APSS), needs a `virtual` destructor.

This PR adds the virtual destructor to `MlsSurface` and fixes the bug.