### PR TITLE
Fix external lib paths on Linux.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -52,12 +52,12 @@ MAKE_FLAGS=('-j11')
 * Build:
 ```
 cd src/external
-qmake external.pro $QMAKE_FLAGS && make $MAKE_FLAGS
+qmake external.pro ${QMAKE_FLAGS[@]} && make ${MAKE_FLAGS[@]} 
 cd ../common
-qmake common.pro $QMAKE_FLAGS && make $MAKE_FLAGS
+qmake common.pro ${QMAKE_FLAGS[@]} && make ${MAKE_FLAGS[@]}
 cd ..
-qmake meshlab_mini.pro $QMAKE_FLAGS && make $MAKE_FLAGS
-qmake meshlab_full.pro $QMAKE_FLAGS && make $MAKE_FLAGS
+qmake meshlab_mini.pro ${QMAKE_FLAGS[@]} && make ${MAKE_FLAGS[@]}
+qmake meshlab_full.pro ${QMAKE_FLAGS[@]} && make ${MAKE_FLAGS[@]}
 ```
 * Run:
 ```

--- a/src/external/ext_common.pri
+++ b/src/external/ext_common.pri
@@ -12,7 +12,7 @@ win32-msvc2015:DEFINES += _CRT_SECURE_NO_WARNINGS
 win32-msvc2017:DEFINES += _CRT_SECURE_NO_WARNINGS
 win32-msvc:DEFINES += _CRT_SECURE_NO_WARNINGS
 
-linux:DESTDIR = $$EXTERNAL_BASE_PATH/lib/linux
+linux:DESTDIR = $$EXTERNAL_BASE_PATH/lib/linux-g++
 
 unix:CONFIG(release, debug|release) {
 	DEFINES *= NDEBUG

--- a/src/meshlab/meshlab.pro
+++ b/src/meshlab/meshlab.pro
@@ -154,7 +154,7 @@ win32-g++:LIBS        	+= -L../external/lib/win32-gcc -ljhead -L../distrib -lcom
 #	win32-g++:release:LIBS 			+= -L../common/release -lcommon
 #}
 
-linux:LIBS += -L$$PWD/../external/lib/linux -ljhead -L../distrib -lcommon -lGLU
+linux:LIBS += -L$$PWD/../external/lib/linux-g++ -ljhead -L../distrib -lcommon -lGLU
 linux:QMAKE_RPATHDIR += ../distrib
 
 # uncomment in your local copy only in emergency cases.


### PR DESCRIPTION
Change the src/external/lib/linux/ to src/external/lib/linux-g++/ paths where relevant.
Also making the instructions in README.md compatible with bash (while not breaking compatibility with zsh).
Solves #285 and #379 .