### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/src/meshlabplugins/filter_mutualglobal/alignGlobal.h
+++ b/src/meshlabplugins/filter_mutualglobal/alignGlobal.h
@@ -53,7 +53,7 @@ public:
 
 	bool valid;
 
-	bool CreatePair(int imId, int prId, int mId, float mut, float ar, bool val) {imageId=imId; projId=prId, meshId=mId, mutual=mut; area=ar; valid=val; }
+	void CreatePair(int imId, int prId, int mId, float mut, float ar, bool val) {imageId=imId; projId=prId, meshId=mId, mutual=mut; area=ar; valid=val; }
 
 	
 


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.