### PR TITLE
Meshlabserver ASCII output for STL and other files

### DIFF
--- a/src/meshlabserver/mainserver.cpp
+++ b/src/meshlabserver/mainserver.cpp
@@ -225,7 +225,11 @@ public:
         // optional saving parameters (like ascii/binary encoding)
         RichParameterSet savePar;
         pCurrentIOPlugin->initSaveParameter(extension, *mm, savePar);
-        if(savePar.hasParameter("Binary")){
+        
+/* The commented code below is me just hacking around getting a feel for
+ * how to use RichParameter sets */
+
+/*        if(savePar.hasParameter("Binary")){
             printf("Binary is a parameter\n");
             if(savePar.getBool("Binary")){
                     printf("Binary is set\n");
@@ -244,6 +248,12 @@ public:
             printf("Write ascii\n");
             savePar.setValue("Binary",BoolValue(false));
         }
+*/
+
+        if(savePar.hasParameter("Binary")){
+            savePar.setValue("Binary",BoolValue(writebinary));
+        }
+        
         int formatmask = 0;
         int defbits = 0;
         pCurrentIOPlugin->GetExportMaskCapability(extension,formatmask,defbits);
@@ -623,6 +633,7 @@ namespace commandline
     const char log('l');
     const char dump('d');
     const char script('s');
+    const char saveparam('s');
     const char ascii('a');
 
     void usage()
@@ -654,7 +665,7 @@ namespace commandline
 
     QString outputmeshExpression()
     {
-		QString options("(" + QString(vertex) + "|" + QString(face) + "|" + QString(wedge) + "|" + QString(mesh) + "|" +QString(ascii) + ")(" + QString(color) + "|" + QString(quality) + "|" + QString(flags) + "|" + QString(normal) + "|" + QString(radius) + "|" + QString(texture) + "|" + QString(polygon) + "|" + QString(ascii) + ")");
+		QString options("(" + QString(vertex) + "|" + QString(face) + "|" + QString(wedge) + "|" + QString(mesh) + "|" +QString(saveparam) + ")(" + QString(color) + "|" + QString(quality) + "|" + QString(flags) + "|" + QString(normal) + "|" + QString(radius) + "|" + QString(texture) + "|" + QString(polygon) + "|" + QString(ascii) + ")");
 		QString optionslist(options + "(\\s+" + options + ")*");	
 		QString savingmask("-" + QString(mask) + "\\s+" + optionslist);
 		QString layernumber("\\d+");
@@ -938,7 +949,7 @@ int main(int argc, char *argv[])
                                 break;
                             }
 						
-                        case commandline::ascii :
+                        case commandline::saveparam :
                              {
                                 switch( argv[i][1])
                                 {

--- a/src/meshlabserver/meshlabserver.txt
+++ b/src/meshlabserver/meshlabserver.txt
@@ -52,7 +52,8 @@ meshlabserver [logargs] [args]
                           wn-> wedge normals,
                           wt -> wedge texture coords,
                           mp -> polygonal mesh info
-
+                          sa -> save in ascii format
+ 
     -s filename         the script to be applied
 
 


### PR DESCRIPTION
I needed this for my personal workflow, and it seems others (such as issue #410 ) needed it too.  Not very used to collaboration on github, apologies if I've committed any errors of etiquette.

I've modified meshlabserver.cpp to accept a new 'sa' option as part of the '-m' parameter.  The regex for command line parsing and text file from which the help screen is generated has been updated.

If 'sa' is set, then a writebinary flag is switched from the default of 'true' to 'false' and eventually the change gets stored in the saveParameter RichParameter set.  I think I've covered my bases here, but I'm still getting used to the code architecture.  Definitely not sure if I chose the correct part of the parameter list for 'sa' to live in or if this works with projects, since my workflow is one stl at a time.