### PR TITLE
fix: Snapshot w/ transparency on Linux

### DIFF
--- a/src/meshlab/main.cpp
+++ b/src/meshlab/main.cpp
@@ -23,6 +23,7 @@
 #include <common/mlapplication.h>
 #include <QMessageBox>
 #include "mainwindow.h"
+#include <QGLFormat>
 #include <QString>
 #include <clocale>
 
@@ -40,7 +41,11 @@ int main(int argc, char *argv[])
 
     QString tmp = MeshLabApplication::appArchitecturalName(MeshLabApplication::HW_ARCHITECTURE(QSysInfo::WordSize));
     QCoreApplication::setApplicationName(MeshLabApplication::appArchitecturalName(MeshLabApplication::HW_ARCHITECTURE(QSysInfo::WordSize)));
-   
+
+    QGLFormat fmt = QGLFormat::defaultFormat();
+    fmt.setAlphaBufferSize(8);
+    QGLFormat::setDefaultFormat(fmt);
+
     MainWindow window;
     window.showMaximized();
 

--- a/src/meshlabserver/mainserver.cpp
+++ b/src/meshlabserver/mainserver.cpp
@@ -34,6 +34,7 @@
 #include "../meshlab/mainwindow.h"
 #include <clocale>
 
+#include <QGLFormat>
 #include <QFileInfo>
 
 
@@ -733,6 +734,10 @@ int main(int argc, char *argv[])
 
 	std::ptrdiff_t maxgpumem = (std::ptrdiff_t) gpumemmb * (float)(1024 * 1024);
 	vcg::QtThreadSafeMemoryInfo gpumeminfo(maxgpumem);
+
+    QGLFormat fmt = QGLFormat::defaultFormat();
+    fmt.setAlphaBufferSize(8);
+    QGLFormat::setDefaultFormat(fmt);
 
 	MeshDocument meshDocument;
 


### PR DESCRIPTION
Resolves #474 - and maybe also a few other locations that try to use the alpha channel.

I added the change to the meshlabserver as well, although I am not sure if the server supports creating snapshots - so that part is untested.