### PR TITLE
Use bitand instead of logical AND for bitmask

### DIFF
--- a/src/meshlabplugins/io_base/baseio.cpp
+++ b/src/meshlabplugins/io_base/baseio.cpp
@@ -363,7 +363,7 @@ bool BaseMeshIOPlugin::save(const QString &formatName, const QString &fileName, 
 	}
 	if (formatName.toUpper() == tr("OFF"))
 	{
-		if (mask && tri::io::Mask::IOM_BITPOLYGONAL)
+		if (mask & tri::io::Mask::IOM_BITPOLYGONAL)
 			m.updateDataMask(MeshModel::MM_FACEFACETOPO);
 		int result = tri::io::ExporterOFF<CMeshO>::Save(m.cm, filename.c_str(), mask);
 		if (result != 0)


### PR DESCRIPTION
The bit mask has been erroneously checked with logical AND `&&` instead of bitand `&` as done in all other checks nearby.