### PR TITLE
Add virtual default destructor to base class

### DIFF
--- a/src/meshlabplugins/filter_fractal/filter_functors.h
+++ b/src/meshlabplugins/filter_fractal/filter_functors.h
@@ -15,6 +15,7 @@ template<class ScalarType>
 class Normalized3DFunctor
 {
 public:
+	virtual ~Normalized3DFunctor() = default;
     virtual ScalarType operator()(const Point3<ScalarType>& normalizedPoint) = 0;
 };
 


### PR DESCRIPTION
As already writen in cnr-isti-vclab/vcglib#64 I looked at missing virtual destructor warnings as they may point to possible resource leaks. This is the commit that fixes the warnings from MeshLab compilation that are not in VCGLib.

In this case there might be an actual resource leak, as I'm not sure which pointer types are used to delete all subclasses of `Normalized3DFunctor`.