### PR TITLE
Add const to actually override virtual functions

### DIFF
--- a/src/meshlabplugins/edit_paint/edit_paint.h
+++ b/src/meshlabplugins/edit_paint/edit_paint.h
@@ -205,14 +205,14 @@ public:
 		original = c; // setText("Single Vertex Color Change");
 	}
 
-	virtual void undo()
+	virtual void undo() override
 	{ 
 		vcg::Color4b temp = vertex->C(); 
 		vertex->C() = original; 
 		original = temp; 
 	}
-	virtual void redo() { undo(); }
-	virtual int id() { return COLOR_PAINT; }
+	virtual void redo() override { undo(); }
+	virtual int id() const override { return COLOR_PAINT; }
 
 private:
 	CVertexO* vertex;
@@ -229,12 +229,12 @@ public:
 		vertex = v; original = p; normal = n;
 	}
 
-	virtual void undo() {
+	virtual void undo() override {
 		Point3m temp = vertex->P(); vertex->P() = original; original = temp;
 		temp = vertex->N(); vertex->N() = normal; normal = temp;
 	}
-	virtual void redo() { undo(); }
-	virtual int id() { return MESH_PULL; }
+	virtual void redo() override { undo(); }
+	virtual int id() const override { return MESH_PULL; }
 
 private:
 	CVertexO* vertex;
@@ -255,9 +255,9 @@ public:
 		face = f; original = sel; // setText("Single Vertex Color Change");
 	}
 
-	virtual void undo() { bool temp = face->IsS(); original ? face->SetS() : face->ClearS(); original = temp; }
-	virtual void redo() { undo(); }
-	virtual int id() { return MESH_SELECT; }
+	virtual void undo() override { bool temp = face->IsS(); original ? face->SetS() : face->ClearS(); original = temp; }
+	virtual void redo() override { undo(); }
+	virtual int id() const override { return MESH_SELECT; }
 private:
 	CFaceO * face;
 	bool original;


### PR DESCRIPTION
Parts of the Qt undo functionality were hidden instead of overriden, as the functions were missing `const`. This adds the missing `const` to actually override the intended function.
Also added `override` to all virtual functions to prevent future errors.