### PR TITLE
Put Start shortcuts in allusers profile instead of currentuser

### DIFF
--- a/src/install/meshlab.nsi
+++ b/src/install/meshlab.nsi
@@ -58,6 +58,7 @@ Section "MainSection" SEC01
   File "${DISTRIB_FOLDER}\meshlab.exe"
   File "${DISTRIB_FOLDER}\meshlabserver.exe"
 
+  SetShellVarContext all
   CreateDirectory "$SMPROGRAMS\MeshLab"
   CreateShortCut "$SMPROGRAMS\MeshLab\MeshLab.lnk" "$INSTDIR\meshlab.exe"
   CreateShortCut "$DESKTOP\MeshLab.lnk" "$INSTDIR\meshlab.exe"
@@ -314,6 +315,7 @@ Section Uninstall
   Delete "$INSTDIR\textures\*.jpg"
   Delete "$INSTDIR\textures\*.tga"
 
+  SetShellVarContext all
   Delete "$SMPROGRAMS\MeshLab\Uninstall.lnk"
   Delete "$SMPROGRAMS\MeshLab\Website.lnk"
   Delete "$DESKTOP\MeshLab.lnk"


### PR DESCRIPTION
The default shell context in NSIS is for the current user. This causes $SMPROGRAMS to put the link in the current user's profile. Other users on the system get no start menu link. This is causing me trouble because I'm trying to deploy Meshlab in a school and by default only the user that installs the application gets the Start Menu shortcuts.

Docs for SetShellVarContext at https://nsis.sourceforge.io/Docs/Chapter4.html