### PR TITLE
Replace variadic functions with variadic templates

### DIFF
--- a/src/common/GLLogStream.cpp
+++ b/src/common/GLLogStream.cpp
@@ -34,29 +34,6 @@ GLLogStream::GLLogStream()
   ClearBookmark();
 }
 
-void GLLogStream::Logf(int Level, const char * f, ... )
-{
-	char buf[4096];
-	va_list marker;
-	va_start( marker, f );     
-
-	vsprintf(buf,f,marker);
-	va_end( marker );              
-	Log(Level,buf);
-}
-
-void GLLogStream::RealTimeLogf(const QString& Id, const QString &meshName, const char * f, ... )
-{
-	char buf[4096];
-	va_list marker;
-	va_start( marker, f );
-
-	vsprintf(buf,f,marker);
-	va_end( marker );
-	QString tmp(buf);
-	RealTimeLog(Id,meshName,tmp);
-}
-
 void GLLogStream::RealTimeLog(const QString& Id, const QString &meshName, const QString& text)
 {
   this->RealTimeLogText.insert(Id,qMakePair(meshName,text) );

--- a/src/common/GLLogStream.h
+++ b/src/common/GLLogStream.h
@@ -47,12 +47,25 @@ public:
 		DEBUG = 3
 	};
 
+	static constexpr std::size_t buf_size = 4096;
+
 	GLLogStream();
 	~GLLogStream() {}
 	void print(QStringList &list);		// Fills a QStringList with the log entries
 	void Save(int Level, const char *filename);
 	void Clear();
-	void Logf(int Level, const char * f, ...);
+	template <typename... Ts>
+	void Logf(int Level, const char * f, Ts&&... ts )
+	{
+		char buf[buf_size];
+		int chars_written = snprintf(buf, buf_size, f, std::forward<Ts>(ts)...);   
+		Log(Level, buf);
+
+		if(chars_written >= static_cast<int>(buf_size)){
+			Log(Level, "Log message truncated.");
+		}
+	}
+
 	void Log(int Level, const char * buf);
 
 	void SetBookmark();
@@ -67,7 +80,17 @@ public:
 	// the name of the mesh is shown only if two or more box with the same title are shown.
 	QMultiMap<QString, QPair<QString, QString> > RealTimeLogText;
 
-	void RealTimeLogf(const QString& Id, const QString &meshName, const char * f, ...);
+	template <typename... Ts>
+	void RealTimeLogf(const QString& Id, const QString &meshName, const char * f, Ts&&... ts )
+	{
+		char buf[buf_size];
+		int chars_written = snprintf(buf, buf_size, f, std::forward<Ts>(ts)...);   
+		RealTimeLog(Id, meshName, buf);
+
+		if(chars_written >= static_cast<int>(buf_size)){
+			RealTimeLog(Id, meshName, "Log message truncated.");
+		}
+	}	
 	void RealTimeLog(const QString& Id, const QString &meshName, const QString& text);
 
 signals:

--- a/src/common/interfaces.cpp
+++ b/src/common/interfaces.cpp
@@ -1,45 +1,5 @@
 #include "interfaces.h"
 
-void MeshLabInterface::Log(const char * f, ... )
-{
-  if(log)
-  {
-    char buf[4096];
-    va_list marker;
-    va_start( marker, f );
-    vsprintf(buf,f,marker);
-    va_end( marker );
-    log->Log(GLLogStream::FILTER,buf);
-  }
-}
-
-
-void MeshLabInterface::Log(int Level, const char * f, ... )
-{
-  if(log)
-  {
-    char buf[4096];
-    va_list marker;
-    va_start( marker, f );
-    vsprintf(buf,f,marker);
-    va_end( marker );
-    log->Log(Level,buf);
-  }
-}
-
-void MeshLabInterface::RealTimeLog(QString Id, const QString &meshName, const char * f, ... )
-{
-  if(log)
-  {
-    char buf[4096];
-    va_list marker;
-    va_start( marker, f );
-    vsprintf(buf,f,marker);
-    va_end( marker );
-    log->RealTimeLog(Id, meshName,buf);
-  }
-}
-
 bool MeshFilterInterface::isFilterApplicable(QAction *act, const MeshModel& m, QStringList &MissingItems) const
 {
   int preMask = getPreConditions(act);

--- a/src/common/interfaces.h
+++ b/src/common/interfaces.h
@@ -100,9 +100,32 @@ public:
 	void setLog(GLLogStream *log) { this->log = log; }
 	// This fucntion must be used to communicate useful information collected in the parsing/saving of the files.
 	// NEVER EVER use a msgbox to say something to the user.
-	void Log(const char * f, ...);
-	void Log(int Level, const char * f, ...);
-	void RealTimeLog(QString Id, const QString &meshName, const char * f, ...);
+	template <typename... Ts>
+	void Log(const char * f, Ts&&... ts )
+	{
+		if(log != nullptr)
+		{
+			log->Logf(GLLogStream::FILTER, f, std::forward<Ts>(ts)...);
+		}
+	}
+
+	template <typename... Ts>
+	void Log(int Level, const char * f, Ts&&... ts )
+	{
+		if(log != nullptr)
+		{
+			log->Logf(Level, f, std::forward<Ts>(ts)...);
+		}
+	}
+
+	template <typename... Ts>
+	void RealTimeLog(QString Id, const QString &meshName, const char * f, Ts&&... ts )
+	{
+		if(log != nullptr)
+		{
+			log->RealTimeLogf(Id, meshName, f, std::forward<Ts>(ts)...);
+		}
+	}
 };
 
 class MeshCommonInterface : public MeshLabInterface

--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -152,21 +152,6 @@ QString GLArea::GetMeshInfoString()
     return info;
 }
 
-
-void GLArea::Logf(int Level, const char * f, ... )
-{
-	makeCurrent();
-    if(this->md()==0) return;
-
-    char buf[4096];
-    va_list marker;
-    va_start( marker, f );
-
-    vsprintf(buf,f,marker);
-    va_end( marker );
-    this->md()->Log.Log(Level,buf);
-}
-
 QSize GLArea::minimumSizeHint() const {return QSize(400,300);}
 QSize GLArea::sizeHint() const				{return QSize(400,300);}
 

--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -131,7 +131,14 @@ public:
 
     vcg::Trackball trackball;
     vcg::Trackball trackball_light;
-    void Logf(int Level, const char * f, ... );
+    template <typename... Ts>
+    void Logf(int Level, const char * f, Ts&&... ts)
+    {
+        makeCurrent();
+        if( this->md() != nullptr){
+            this->md()->Log.Logf(Level, f, std::forward<Ts>(ts)...);
+        }
+    }
 
     GLAreaSetting glas;
     QSize minimumSizeHint() const;


### PR DESCRIPTION
I noticed that `vsprintf` was in some places in meshlab and wanted to replace them with `vsnprintf`, which is in standard c++ since c++11, in order to prevent buffer overflows. 

However, I would have to replace it in multiple places an thought I would be nicer to replace the c variadic functions with c++ variadic templates.

I'm not sure if you are open to PRs like that, so I limited myself to just a view files.