### PR TITLE
Fix: Update topology after face deletion

### DIFF
--- a/src/meshlabplugins/filter_select/meshselect.cpp
+++ b/src/meshlabplugins/filter_select/meshselect.cpp
@@ -318,6 +318,11 @@ switch(ID(action))
 				tri::Allocator<CMeshO>::DeleteVertex(m.cm, *vi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
 		m.UpdateBoxAndNormals();
+		// Update Topology of result mesh
+		if (tri::HasFFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
+		if (tri::HasVFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i vertices, %i faces.", vvn - m.cm.vn, ffn - m.cm.fn);
 	} break;
 
@@ -358,6 +363,11 @@ switch(ID(action))
 				tri::Allocator<CMeshO>::DeleteFace(m.cm, *fi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
 		m.UpdateBoxAndNormals();
+		// Update Topology of result mesh
+		if (tri::HasFFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
+		if (tri::HasVFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i faces.", ffn - m.cm.fn);
 	} break;
 
@@ -376,6 +386,11 @@ switch(ID(action))
 				tri::Allocator<CMeshO>::DeleteVertex(m.cm, *vi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
 		m.UpdateBoxAndNormals();
+		// Update Topology of result mesh
+		if (tri::HasFFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
+		if (tri::HasVFAdjacency(m.cm))
+		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i faces, %i vertices.", ffn - m.cm.fn, vvn - m.cm.vn);
 	} break;
 

--- a/src/meshlabplugins/filter_select/meshselect.cpp
+++ b/src/meshlabplugins/filter_select/meshselect.cpp
@@ -317,12 +317,8 @@ switch(ID(action))
 			if (!(*vi).IsD() && (*vi).IsS())
 				tri::Allocator<CMeshO>::DeleteVertex(m.cm, *vi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
+		m.clearDataMask(MeshModel::MM_VERTFACETOPO);
 		m.UpdateBoxAndNormals();
-		// Update Topology of result mesh
-		if (tri::HasFFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
-		if (tri::HasVFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i vertices, %i faces.", vvn - m.cm.vn, ffn - m.cm.fn);
 	} break;
 
@@ -338,6 +334,7 @@ switch(ID(action))
 				if (!(*fi).IsD())
 					tri::Allocator<CMeshO>::DeleteFace(ml->cm, *fi);
 				ml->clearDataMask(MeshModel::MM_FACEFACETOPO);
+				ml->clearDataMask(MeshModel::MM_VERTFACETOPO);
 				ml->UpdateBoxAndNormals();
 				Log("Layer %i: deleted all %i faces.", ml->id(), ffn - ml->cm.fn);
 			}
@@ -349,6 +346,7 @@ switch(ID(action))
 			if (!(*fi).IsD())
 				tri::Allocator<CMeshO>::DeleteFace(m.cm, *fi);
 			m.clearDataMask(MeshModel::MM_FACEFACETOPO);
+			m.clearDataMask(MeshModel::MM_VERTFACETOPO);
 			m.UpdateBoxAndNormals();
 			Log("Deleted all %i faces.", ffn - m.cm.fn);
 		}
@@ -362,12 +360,8 @@ switch(ID(action))
 			if (!(*fi).IsD() && (*fi).IsS())
 				tri::Allocator<CMeshO>::DeleteFace(m.cm, *fi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
+		m.clearDataMask(MeshModel::MM_VERTFACETOPO);
 		m.UpdateBoxAndNormals();
-		// Update Topology of result mesh
-		if (tri::HasFFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
-		if (tri::HasVFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i faces.", ffn - m.cm.fn);
 	} break;
 
@@ -385,12 +379,8 @@ switch(ID(action))
 			if (!(*vi).IsD() && (*vi).IsS())
 				tri::Allocator<CMeshO>::DeleteVertex(m.cm, *vi);
 		m.clearDataMask(MeshModel::MM_FACEFACETOPO);
+		m.clearDataMask(MeshModel::MM_VERTFACETOPO);
 		m.UpdateBoxAndNormals();
-		// Update Topology of result mesh
-		if (tri::HasFFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::FaceFace(m.cm);    
-		if (tri::HasVFAdjacency(m.cm))
-		    tri::UpdateTopology<CMeshO>::VertexFace(m.cm);
 		Log("Deleted %i faces, %i vertices.", ffn - m.cm.fn, vvn - m.cm.vn);
 	} break;
 


### PR DESCRIPTION
This is a bugfix for issue #500 

Invalidate vertex-face topology of modified meshes after deleting some parts of the mesh. Not doing this can raise an assert in line 1252 of file vcglib/vcg/complex/allocate.h, because some vertex has their cVFp() not updated.