### PR TITLE
Misc fixes

### DIFF
--- a/src/common/filterparameter.cpp
+++ b/src/common/filterparameter.cpp
@@ -35,7 +35,7 @@
 using namespace vcg;
 
 // Very similar to the findParameter but this one does not print out debugstuff.
-bool RichParameterSet::hasParameter(QString name) const
+bool RichParameterSet::hasParameter(const QString& name) const
 {
     QList<RichParameter*>::const_iterator fpli;
     for(fpli=paramList.begin();fpli!=paramList.end();++fpli)
@@ -46,7 +46,7 @@ bool RichParameterSet::hasParameter(QString name) const
     return false;
 }
 // You should never use this one to know if a given parameter is present.
-RichParameter* RichParameterSet::findParameter(QString name) const
+RichParameter* RichParameterSet::findParameter(const QString& name) const
 {
     QList<RichParameter*>::const_iterator fpli;
     for(fpli=paramList.begin();fpli!=paramList.end();++fpli)
@@ -60,7 +60,7 @@ RichParameter* RichParameterSet::findParameter(QString name) const
     return 0;
 }
 
-RichParameterSet& RichParameterSet::removeParameter(QString name){
+RichParameterSet& RichParameterSet::removeParameter(const QString& name){
     paramList.removeAll(findParameter(name));
     return (*this);
 }
@@ -75,29 +75,29 @@ RichParameterSet& RichParameterSet::addParam(RichParameter* pd )
 //--------------------------------------
 
 
-void RichParameterSet::setValue(QString name,const Value& newval){ findParameter(name)->val->set(newval); }
+void RichParameterSet::setValue(const QString& name,const Value& newval){ findParameter(name)->val->set(newval); }
 
 //- All the get<TYPE> are very similar. Nothing interesting here.
 
-        bool RichParameterSet::getBool(QString name)     const { return findParameter(name)->val->getBool(); }
-         int RichParameterSet::getInt(QString name)      const { return findParameter(name)->val->getInt();}
-       float RichParameterSet::getFloat(QString name)    const { return findParameter(name)->val->getFloat();}
-      QColor RichParameterSet::getColor(QString name)    const { return findParameter(name)->val->getColor();}
-     Color4b RichParameterSet::getColor4b(QString name)  const { return ColorConverter::ToColor4b(findParameter(name)->val->getColor());}
-     QString RichParameterSet::getString(QString name)   const { return findParameter(name)->val->getString();}
-   Matrix44f RichParameterSet::getMatrix44(QString name) const { return findParameter(name)->val->getMatrix44f();}
-   Matrix44<MESHLAB_SCALAR> RichParameterSet::getMatrix44m(QString name) const { return Matrix44<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getMatrix44f());}
-     Point3f RichParameterSet::getPoint3f(QString name)  const { return findParameter(name)->val->getPoint3f();}
-     Point3<MESHLAB_SCALAR> RichParameterSet::getPoint3m(QString name)  const { return Point3<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getPoint3f());}
-       Shotf RichParameterSet::getShotf(QString name)    const { return findParameter(name)->val->getShotf();}
-       Shot<MESHLAB_SCALAR> RichParameterSet::getShotm(QString name)    const { return Shot<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getShotf());}
-       float RichParameterSet::getAbsPerc(QString name)  const { return findParameter(name)->val->getAbsPerc();}
-         int RichParameterSet::getEnum(QString name)     const { return findParameter(name)->val->getEnum();}
-QList<float> RichParameterSet::getFloatList(QString name)    const { return findParameter(name)->val->getFloatList();}
- MeshModel * RichParameterSet::getMesh(QString name)         const { return findParameter(name)->val->getMesh();}
-       float RichParameterSet::getDynamicFloat(QString name) const { return findParameter(name)->val->getDynamicFloat();}
-     QString RichParameterSet::getOpenFileName(QString name) const { return findParameter(name)->val->getFileName();}
-     QString RichParameterSet::getSaveFileName(QString name) const { return findParameter(name)->val->getFileName(); }
+        bool RichParameterSet::getBool(const QString& name)     const { return findParameter(name)->val->getBool(); }
+         int RichParameterSet::getInt(const QString& name)      const { return findParameter(name)->val->getInt();}
+       float RichParameterSet::getFloat(const QString& name)    const { return findParameter(name)->val->getFloat();}
+      QColor RichParameterSet::getColor(const QString& name)    const { return findParameter(name)->val->getColor();}
+     Color4b RichParameterSet::getColor4b(const QString& name)  const { return ColorConverter::ToColor4b(findParameter(name)->val->getColor());}
+     QString RichParameterSet::getString(const QString& name)   const { return findParameter(name)->val->getString();}
+   Matrix44f RichParameterSet::getMatrix44(const QString& name) const { return findParameter(name)->val->getMatrix44f();}
+   Matrix44<MESHLAB_SCALAR> RichParameterSet::getMatrix44m(const QString& name) const { return Matrix44<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getMatrix44f());}
+     Point3f RichParameterSet::getPoint3f(const QString& name)  const { return findParameter(name)->val->getPoint3f();}
+     Point3<MESHLAB_SCALAR> RichParameterSet::getPoint3m(const QString& name)  const { return Point3<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getPoint3f());}
+       Shotf RichParameterSet::getShotf(const QString& name)    const { return findParameter(name)->val->getShotf();}
+       Shot<MESHLAB_SCALAR> RichParameterSet::getShotm(const QString& name)    const { return Shot<MESHLAB_SCALAR>::Construct(findParameter(name)->val->getShotf());}
+       float RichParameterSet::getAbsPerc(const QString& name)  const { return findParameter(name)->val->getAbsPerc();}
+         int RichParameterSet::getEnum(const QString& name)     const { return findParameter(name)->val->getEnum();}
+QList<float> RichParameterSet::getFloatList(const QString& name)    const { return findParameter(name)->val->getFloatList();}
+ MeshModel * RichParameterSet::getMesh(const QString& name)         const { return findParameter(name)->val->getMesh();}
+       float RichParameterSet::getDynamicFloat(const QString& name) const { return findParameter(name)->val->getDynamicFloat();}
+     QString RichParameterSet::getOpenFileName(const QString& name) const { return findParameter(name)->val->getFileName();}
+     QString RichParameterSet::getSaveFileName(const QString& name) const { return findParameter(name)->val->getFileName(); }
 
 RichParameterSet& RichParameterSet::operator=( const RichParameterSet& rps )
 {
@@ -159,7 +159,7 @@ RichParameterSet::RichParameterSet( const RichParameterSet& rps )
     }
 }
 
-RichParameterSet::RichParameterSet() :paramList()
+RichParameterSet::RichParameterSet()
 {
 
 }
@@ -628,7 +628,7 @@ BoolValue::BoolValue( const bool val ) : pval(val)
 
 }
 
-ParameterDecoration::ParameterDecoration( Value* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :fieldDesc(desc),tooltip(tltip),defVal(defvalue)
+ParameterDecoration::ParameterDecoration( Value* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :fieldDesc(desc),tooltip(tltip),defVal(defvalue)
 {
 
 }
@@ -638,71 +638,71 @@ ParameterDecoration::~ParameterDecoration()
     delete defVal;
 }
 
-BoolDecoration::BoolDecoration( BoolValue* defvalue,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+BoolDecoration::BoolDecoration( BoolValue* defvalue,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-IntDecoration::IntDecoration( IntValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+IntDecoration::IntDecoration( IntValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-FloatDecoration::FloatDecoration( FloatValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+FloatDecoration::FloatDecoration( FloatValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-StringDecoration::StringDecoration( StringValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+StringDecoration::StringDecoration( StringValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-Matrix44fDecoration::Matrix44fDecoration( Matrix44fValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+Matrix44fDecoration::Matrix44fDecoration( Matrix44fValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-Point3fDecoration::Point3fDecoration( Point3fValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+Point3fDecoration::Point3fDecoration( Point3fValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
-ShotfDecoration::ShotfDecoration( ShotfValue* defvalue,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
-{
-
-}
-
-ColorDecoration::ColorDecoration( ColorValue* defvalue,const QString desc /*= QString()*/,const QString tltip/*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
+ShotfDecoration::ShotfDecoration( ShotfValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-AbsPercDecoration::AbsPercDecoration( AbsPercValue* defvalue,const float minVal,const float maxVal,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),min(minVal),max(maxVal)
+ColorDecoration::ColorDecoration( ColorValue* defvalue,const QString& desc /*= QString()*/,const QString& tltip/*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip)
 {
 
 }
 
-EnumDecoration::EnumDecoration( EnumValue* defvalue, QStringList values,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),enumvalues(values)
+AbsPercDecoration::AbsPercDecoration( AbsPercValue* defvalue,const float minVal,const float maxVal,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),min(minVal),max(maxVal)
 {
 
 }
 
-DynamicFloatDecoration::DynamicFloatDecoration( DynamicFloatValue* defvalue, const float minVal,const float maxVal,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),min(minVal),max(maxVal)
+EnumDecoration::EnumDecoration( EnumValue* defvalue, QStringList values,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),enumvalues(std::move(values))
 {
 
 }
 
-SaveFileDecoration::SaveFileDecoration( FileValue* defvalue,const QString extension/*=QString(".*")*/,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),ext(extension)
+DynamicFloatDecoration::DynamicFloatDecoration( DynamicFloatValue* defvalue, const float minVal,const float maxVal,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),min(minVal),max(maxVal)
 {
 
 }
 
-OpenFileDecoration::OpenFileDecoration( FileValue* directorydefvalue,const QStringList extensions,const QString desc /*= QString()*/,const QString tltip /*= QString()*/ ) :ParameterDecoration(directorydefvalue,desc,tltip),exts(extensions)
+SaveFileDecoration::SaveFileDecoration( FileValue* defvalue,const QString& extension/*=QString(".*")*/,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),ext(extension)
 {
 
 }
 
-MeshDecoration::MeshDecoration( MeshValue* defvalue,MeshDocument* doc,const QString desc/*=QString()*/, const QString tltip/*=QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),meshdoc(doc)
+OpenFileDecoration::OpenFileDecoration( FileValue* directorydefvalue,const QStringList& extensions,const QString& desc /*= QString()*/,const QString& tltip /*= QString()*/ ) :ParameterDecoration(directorydefvalue,desc,tltip),exts(extensions)
+{
+
+}
+
+MeshDecoration::MeshDecoration( MeshValue* defvalue,MeshDocument* doc,const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/ ) :ParameterDecoration(defvalue,desc,tltip),meshdoc(doc)
 {
     meshindex = -1;
     if (doc != NULL)
@@ -710,7 +710,7 @@ MeshDecoration::MeshDecoration( MeshValue* defvalue,MeshDocument* doc,const QStr
     assert((meshindex != -1) || (doc == NULL));
 }
 
-MeshDecoration::MeshDecoration( int meshind,MeshDocument* doc,const QString desc/*=QString()*/, const QString tltip/*=QString()*/ ) :ParameterDecoration(NULL,desc,tltip),meshdoc(doc)
+MeshDecoration::MeshDecoration( int meshind,MeshDocument* doc,const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/ ) :ParameterDecoration(NULL,desc,tltip),meshdoc(doc)
 {
     assert(meshind < doc->size() && meshind >= 0);
     meshindex = meshind;
@@ -718,12 +718,12 @@ MeshDecoration::MeshDecoration( int meshind,MeshDocument* doc,const QString desc
         defVal = new MeshValue(doc->meshList.at(meshind));
 }
 
-MeshDecoration::MeshDecoration( int meshind,const QString desc/*=QString()*/,const QString tooltip/*=QString()*/) :ParameterDecoration(NULL,desc,tooltip),meshdoc(NULL),meshindex(meshind)
+MeshDecoration::MeshDecoration( int meshind,const QString& desc/*=QString()*/,const QString& tooltip/*=QString()*/) :ParameterDecoration(NULL,desc,tooltip),meshdoc(NULL),meshindex(meshind)
 {
 
 }
 
-RichParameter::RichParameter(const QString nm, Value* v, ParameterDecoration* prdec, bool isxmlpar) : name(nm), val(v), pd(prdec), isxmlparam(isxmlpar)
+RichParameter::RichParameter(const QString& nm, Value* v, ParameterDecoration* prdec, bool isxmlpar) : name(nm), val(v), pd(prdec), isxmlparam(isxmlpar)
 {
 
 }
@@ -742,11 +742,11 @@ RichBool::RichBool( const QString nm,const bool defval,const QString desc) : Ric
 
 }
 */
-RichBool::RichBool( const QString nm,const bool defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) : RichParameter(nm,new BoolValue(defval),new BoolDecoration(new BoolValue(defval),desc,tltip))
+RichBool::RichBool( const QString& nm,const bool defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) : RichParameter(nm,new BoolValue(defval),new BoolDecoration(new BoolValue(defval),desc,tltip))
 {}
 
 
-RichBool::RichBool(const QString nm, const bool val, const bool defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new BoolValue(val), new BoolDecoration(new BoolValue(defval), desc, tltip), isxmlpar)
+RichBool::RichBool(const QString& nm, const bool val, const bool defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new BoolValue(val), new BoolDecoration(new BoolValue(defval), desc, tltip), isxmlpar)
 {}
 
 void RichBool::accept( Visitor& v )
@@ -764,12 +764,12 @@ RichBool::~RichBool()
 
 }
 
-RichInt::RichInt( const QString nm,const int defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new IntValue(defval),new IntDecoration(new IntValue(defval),desc,tltip))
+RichInt::RichInt( const QString& nm,const int defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new IntValue(defval),new IntDecoration(new IntValue(defval),desc,tltip))
 {
 
 }
 
-RichInt::RichInt(const QString nm, const int val, const int defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new IntValue(val), new IntDecoration(new IntValue(defval), desc, tltip), isxmlpar)
+RichInt::RichInt(const QString& nm, const int val, const int defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new IntValue(val), new IntDecoration(new IntValue(defval), desc, tltip), isxmlpar)
 {
 
 }
@@ -789,12 +789,12 @@ RichInt::~RichInt()
 
 }
 
-RichFloat::RichFloat( const QString nm,const float defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new FloatValue(defval),new FloatDecoration(new FloatValue(defval),desc,tltip))
+RichFloat::RichFloat( const QString& nm,const float defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new FloatValue(defval),new FloatDecoration(new FloatValue(defval),desc,tltip))
 {
 
 }
 
-RichFloat::RichFloat(const QString nm, const float val, const float defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new FloatValue(val), new FloatDecoration(new FloatValue(defval), desc, tltip), isxmlpar)
+RichFloat::RichFloat(const QString& nm, const float val, const float defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new FloatValue(val), new FloatDecoration(new FloatValue(defval), desc, tltip), isxmlpar)
 {
 
 }
@@ -814,22 +814,22 @@ RichFloat::~RichFloat()
 
 }
 
-RichString::RichString( const QString nm,const QString defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),desc,tltip))
+RichString::RichString( const QString& nm,const QString& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),desc,tltip))
 {
 
 }
 
-RichString::RichString(const QString nm, const QString val, const QString defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new StringValue(val), new StringDecoration(new StringValue(defval), desc, tltip), isxmlpar)
+RichString::RichString(const QString& nm, const QString& val, const QString& defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new StringValue(val), new StringDecoration(new StringValue(defval), desc, tltip), isxmlpar)
 {
 
 }
 
-RichString::RichString( const QString nm,const QString defval ) : RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),"",""))
+RichString::RichString( const QString& nm,const QString& defval ) : RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),"",""))
 {
 
 }
 
-RichString::RichString( const QString nm,const QString defval,const QString desc ) : RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),desc,""))
+RichString::RichString( const QString& nm,const QString& defval,const QString& desc ) : RichParameter(nm,new StringValue(defval),new StringDecoration(new StringValue(defval),desc,""))
 {
 
 }
@@ -849,10 +849,10 @@ RichString::~RichString()
 
 }
 
-RichMatrix44f::RichMatrix44f( const QString nm,const vcg::Matrix44f& defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new Matrix44fValue(defval),new Matrix44fDecoration(new Matrix44fValue(defval),desc,tltip)) { }
-RichMatrix44f::RichMatrix44f( const QString nm,const vcg::Matrix44d& defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new Matrix44fValue(defval),new Matrix44fDecoration(new Matrix44fValue(defval),desc,tltip)) { }
+RichMatrix44f::RichMatrix44f( const QString& nm,const vcg::Matrix44f& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new Matrix44fValue(defval),new Matrix44fDecoration(new Matrix44fValue(defval),desc,tltip)) { }
+RichMatrix44f::RichMatrix44f( const QString& nm,const vcg::Matrix44d& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new Matrix44fValue(defval),new Matrix44fDecoration(new Matrix44fValue(defval),desc,tltip)) { }
 
-RichMatrix44f::RichMatrix44f(const QString nm, const vcg::Matrix44f& val, const vcg::Matrix44f& defval, const QString desc /*= QString()*/, const QString tltip /*= QString()*/, bool /*isxmlpar = false*/)
+RichMatrix44f::RichMatrix44f(const QString& nm, const vcg::Matrix44f& val, const vcg::Matrix44f& defval, const QString& desc /*= QString()*/, const QString& tltip /*= QString()*/, bool /*isxmlpar = false*/)
 	: RichParameter(nm, new Matrix44fValue(val), new Matrix44fDecoration(new Matrix44fValue(defval), desc, tltip)) { }
 
 void RichMatrix44f::accept( Visitor& v )
@@ -870,10 +870,10 @@ RichMatrix44f::~RichMatrix44f()
 
 }
 
-RichPoint3f::RichPoint3f( const QString nm,const vcg::Point3f defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new Point3fValue(defval),new Point3fDecoration(new Point3fValue(defval),desc,tltip)){}
-RichPoint3f::RichPoint3f( const QString nm,const vcg::Point3d defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new Point3fValue(defval),new Point3fDecoration(new Point3fValue(defval),desc,tltip)){}
+RichPoint3f::RichPoint3f( const QString& nm,const vcg::Point3f& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new Point3fValue(defval),new Point3fDecoration(new Point3fValue(defval),desc,tltip)){}
+RichPoint3f::RichPoint3f( const QString& nm,const vcg::Point3d& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new Point3fValue(defval),new Point3fDecoration(new Point3fValue(defval),desc,tltip)){}
 
-RichPoint3f::RichPoint3f(const QString nm, const vcg::Point3f val, const vcg::Point3f defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new Point3fValue(val), new Point3fDecoration(new Point3fValue(defval), desc, tltip), isxmlpar)
+RichPoint3f::RichPoint3f(const QString& nm, const vcg::Point3f& val, const vcg::Point3f& defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new Point3fValue(val), new Point3fDecoration(new Point3fValue(defval), desc, tltip), isxmlpar)
 {
 
 }
@@ -893,10 +893,10 @@ RichPoint3f::~RichPoint3f()
 
 }
 //----
-RichShotf::RichShotf( const QString nm,const vcg::Shotf defval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new ShotfValue(defval),new ShotfDecoration(new ShotfValue(defval),desc,tltip))
+RichShotf::RichShotf( const QString& nm,const vcg::Shotf& defval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new ShotfValue(defval),new ShotfDecoration(new ShotfValue(defval),desc,tltip))
 {}
 
-RichShotf::RichShotf(const QString nm, const vcg::Shotf val, const vcg::Shotf defval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new ShotfValue(val), new ShotfDecoration(new ShotfValue(defval), desc, tltip), isxmlpar)
+RichShotf::RichShotf(const QString& nm, const vcg::Shotf& val, const vcg::Shotf& defval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new ShotfValue(val), new ShotfDecoration(new ShotfValue(defval), desc, tltip), isxmlpar)
 {}
 
 void RichShotf::accept( Visitor& v )
@@ -912,23 +912,23 @@ bool RichShotf::operator==( const RichParameter& rb )
 RichShotf::~RichShotf()
 { }
 //----
-RichColor::RichColor( const QString nm,const QColor defval,const QString desc,const QString tltip ) :RichParameter(nm,new ColorValue(defval),new ColorDecoration(new ColorValue(defval),desc,tltip))
+RichColor::RichColor( const QString& nm,const QColor& defval,const QString& desc,const QString& tltip ) :RichParameter(nm,new ColorValue(defval),new ColorDecoration(new ColorValue(defval),desc,tltip))
 {
 
 }
 
-RichColor::RichColor(const QString nm, const QColor val, const QColor defval, const QString desc, const QString tltip, bool isxmlpar) : RichParameter(nm, new ColorValue(val), new ColorDecoration(new ColorValue(defval), desc, tltip), isxmlpar)
+RichColor::RichColor(const QString& nm, const QColor& val, const QColor& defval, const QString& desc, const QString& tltip, bool isxmlpar) : RichParameter(nm, new ColorValue(val), new ColorDecoration(new ColorValue(defval), desc, tltip), isxmlpar)
 {
 
 }
 
-RichColor::RichColor( const QString nm,const QColor defval )
+RichColor::RichColor( const QString& nm,const QColor& defval )
 :RichParameter(nm,new ColorValue(defval),new ColorDecoration(new ColorValue(defval),"",""))
 {
 
 }
 
-RichColor::RichColor( const QString nm,const QColor defval,const QString desc )
+RichColor::RichColor( const QString& nm,const QColor& defval,const QString& desc )
 :RichParameter(nm,new ColorValue(defval),new ColorDecoration(new ColorValue(defval),desc,""))
 {
 }
@@ -948,12 +948,12 @@ RichColor::~RichColor()
 
 }
 
-RichAbsPerc::RichAbsPerc( const QString nm,const float defval,const float minval,const float maxval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm, new AbsPercValue(defval), new AbsPercDecoration(new AbsPercValue(defval),minval,maxval,desc,tltip))
+RichAbsPerc::RichAbsPerc( const QString& nm,const float defval,const float minval,const float maxval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm, new AbsPercValue(defval), new AbsPercDecoration(new AbsPercValue(defval),minval,maxval,desc,tltip))
 {
 
 }
 
-RichAbsPerc::RichAbsPerc(const QString nm, const float val, const float defval, const float minval, const float maxval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new AbsPercValue(val), new AbsPercDecoration(new AbsPercValue(defval), minval, maxval, desc, tltip), isxmlpar)
+RichAbsPerc::RichAbsPerc(const QString& nm, const float val, const float defval, const float minval, const float maxval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new AbsPercValue(val), new AbsPercDecoration(new AbsPercValue(defval), minval, maxval, desc, tltip), isxmlpar)
 {
 
 }
@@ -973,12 +973,12 @@ RichAbsPerc::~RichAbsPerc()
 
 }
 
-RichEnum::RichEnum( const QString nm,const int defval,const QStringList values,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new EnumValue(defval),new EnumDecoration(new EnumValue(defval),values,desc,tltip))
+RichEnum::RichEnum( const QString& nm,const int defval,const QStringList& values,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new EnumValue(defval),new EnumDecoration(new EnumValue(defval),values,desc,tltip))
 {
 
 }
 
-RichEnum::RichEnum(const QString nm, const int val, const int defval, const QStringList values, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new EnumValue(val), new EnumDecoration(new EnumValue(defval), values, desc, tltip), isxmlpar)
+RichEnum::RichEnum(const QString& nm, const int val, const int defval, const QStringList& values, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new EnumValue(val), new EnumDecoration(new EnumValue(defval), values, desc, tltip), isxmlpar)
 {
 
 }
@@ -998,7 +998,7 @@ RichEnum::~RichEnum()
 
 }
 
-RichMesh::RichMesh( const QString nm,MeshModel* defval,MeshDocument* doc,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ )
+RichMesh::RichMesh( const QString& nm,MeshModel* defval,MeshDocument* doc,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ )
     :RichParameter(nm, new MeshValue(defval),new MeshDecoration( new MeshValue(defval),doc,desc,tltip))
 {
     meshindex = -1;
@@ -1007,7 +1007,7 @@ RichMesh::RichMesh( const QString nm,MeshModel* defval,MeshDocument* doc,const Q
     assert((meshindex != -1) || (doc == NULL));
 }
 
-RichMesh::RichMesh( const QString nm,int meshind,MeshDocument* doc,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ )
+RichMesh::RichMesh( const QString& nm,int meshind,MeshDocument* doc,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ )
     :RichParameter(nm,NULL, new MeshDecoration(meshind,doc,desc,tltip))
 {
     assert(meshind < doc->size() && meshind >= 0);
@@ -1018,13 +1018,13 @@ RichMesh::RichMesh( const QString nm,int meshind,MeshDocument* doc,const QString
         val = NULL;
 }
 
-RichMesh::RichMesh(const QString nm, int meshind, bool isxmlpar /*= false*/)
+RichMesh::RichMesh(const QString& nm, int meshind, bool isxmlpar /*= false*/)
 	: RichParameter(nm, new MeshValue(NULL), new MeshDecoration(meshind), isxmlpar)
 {
 	meshindex = meshind;
 }
 
-RichMesh::RichMesh(const QString nm, MeshModel* val, MeshModel* defval, MeshDocument* doc, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar)
+RichMesh::RichMesh(const QString& nm, MeshModel* val, MeshModel* defval, MeshDocument* doc, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar)
 	: RichParameter(nm, new MeshValue(val), new MeshDecoration(new MeshValue(defval), doc, desc, tltip), isxmlpar)
 {
     meshindex = -1;
@@ -1032,7 +1032,7 @@ RichMesh::RichMesh(const QString nm, MeshModel* val, MeshModel* defval, MeshDocu
         meshindex = doc->meshList.indexOf(val);
 }
 
-RichMesh::RichMesh(const QString nm, int meshind, const QString desc /*= QString()*/, const QString tltip /*= QString()*/, bool isxmlpar /*= false*/)
+RichMesh::RichMesh(const QString& nm, int meshind, const QString& desc /*= QString()*/, const QString& tltip /*= QString()*/, bool isxmlpar /*= false*/)
 	: RichParameter(nm, new MeshValue(NULL), new MeshDecoration(meshind, desc, tltip), isxmlpar)
 {
 	meshindex = meshind;
@@ -1053,12 +1053,12 @@ RichMesh::~RichMesh()
 
 }
 
-RichFloatList::RichFloatList( const QString nm,FloatListValue* v,FloatListDecoration* prdec ) :RichParameter(nm,v,prdec)
+RichFloatList::RichFloatList( const QString& nm,FloatListValue* v,FloatListDecoration* prdec ) :RichParameter(nm,v,prdec)
 {
 
 }
 
-RichFloatList::RichFloatList(const QString nm, FloatListValue* /*val*/, FloatListValue* v, FloatListDecoration* prdec, bool isxmlpar) : RichParameter(nm, v, prdec, isxmlpar)
+RichFloatList::RichFloatList(const QString& nm, FloatListValue* /*val*/, FloatListValue* v, FloatListDecoration* prdec, bool isxmlpar) : RichParameter(nm, v, prdec, isxmlpar)
 {
 
 }
@@ -1078,12 +1078,12 @@ RichFloatList::~RichFloatList()
 
 }
 
-RichDynamicFloat::RichDynamicFloat( const QString nm,const float defval,const float minval,const float maxval,const QString desc/*=QString()*/,const QString tltip/*=QString()*/ ) :RichParameter(nm,new DynamicFloatValue(defval),new DynamicFloatDecoration(new DynamicFloatValue(defval),minval,maxval,desc,tltip))
+RichDynamicFloat::RichDynamicFloat( const QString& nm,const float defval,const float minval,const float maxval,const QString& desc/*=QString()*/,const QString& tltip/*=QString()*/ ) :RichParameter(nm,new DynamicFloatValue(defval),new DynamicFloatDecoration(new DynamicFloatValue(defval),minval,maxval,desc,tltip))
 {
 
 }
 
-RichDynamicFloat::RichDynamicFloat(const QString nm, const float val, const float defval, const float minval, const float maxval, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new DynamicFloatValue(val), new DynamicFloatDecoration(new DynamicFloatValue(defval), minval, maxval, desc, tltip), isxmlpar)
+RichDynamicFloat::RichDynamicFloat(const QString& nm, const float val, const float defval, const float minval, const float maxval, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) : RichParameter(nm, new DynamicFloatValue(val), new DynamicFloatDecoration(new DynamicFloatValue(defval), minval, maxval, desc, tltip), isxmlpar)
 {
 
 }
@@ -1103,7 +1103,7 @@ RichDynamicFloat::~RichDynamicFloat()
 
 }
 
-RichOpenFile::RichOpenFile(const QString nm, const QString directorydefval, const QStringList exts /*= QString("*.*")*/, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) :RichParameter(nm, new FileValue(directorydefval), new OpenFileDecoration(new FileValue(directorydefval), exts, desc, tltip), isxmlpar)
+RichOpenFile::RichOpenFile(const QString& nm, const QString& directorydefval, const QStringList& exts /*= QString("*.*")*/, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) :RichParameter(nm, new FileValue(directorydefval), new OpenFileDecoration(new FileValue(directorydefval), exts, desc, tltip), isxmlpar)
 {
 }
 
@@ -1122,7 +1122,7 @@ RichOpenFile::~RichOpenFile()
 
 }
 
-RichSaveFile::RichSaveFile(const QString nm, const QString filedefval, const QString ext, const QString desc/*=QString()*/, const QString tltip/*=QString()*/, bool isxmlpar) :RichParameter(nm, new FileValue(filedefval), new SaveFileDecoration(new FileValue(filedefval), ext, desc, tltip), isxmlpar) 
+RichSaveFile::RichSaveFile(const QString& nm, const QString& filedefval, const QString& ext, const QString& desc/*=QString()*/, const QString& tltip/*=QString()*/, bool isxmlpar) :RichParameter(nm, new FileValue(filedefval), new SaveFileDecoration(new FileValue(filedefval), ext, desc, tltip), isxmlpar) 
 {
 
 }

--- a/src/common/filterparameter.cpp
+++ b/src/common/filterparameter.cpp
@@ -101,7 +101,8 @@ QList<float> RichParameterSet::getFloatList(QString name)    const { return find
 
 RichParameterSet& RichParameterSet::operator=( const RichParameterSet& rps )
 {
-    return copy(rps);
+    copy(rps);
+    return *this;
 }
 
 bool RichParameterSet::operator==( const RichParameterSet& rps )
@@ -132,13 +133,15 @@ RichParameterSet::~RichParameterSet()
 
 RichParameterSet& RichParameterSet::copy( const RichParameterSet& rps )
 {
-    clear();
+    if (this != &rps) {
+        clear();
 
-    RichParameterCopyConstructor copyvisitor;
-    for(int ii = 0;ii < rps.paramList.size();++ii)
-    {
-        rps.paramList.at(ii)->accept(copyvisitor);
-        paramList.push_back(copyvisitor.lastCreated);
+        RichParameterCopyConstructor copyvisitor;
+        for(int ii = 0;ii < rps.paramList.size();++ii)
+        {
+            rps.paramList.at(ii)->accept(copyvisitor);
+            paramList.push_back(copyvisitor.lastCreated);
+        }
     }
     return (*this);
 }

--- a/src/common/filterparameter.h
+++ b/src/common/filterparameter.h
@@ -332,7 +332,7 @@ public:
 	QString tooltip;
 	Value* defVal;
 
-	ParameterDecoration(Value* defvalue, const QString desc = QString(), const QString tltip = QString());
+	ParameterDecoration(Value* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 
 	virtual ~ParameterDecoration();
 
@@ -341,63 +341,63 @@ public:
 class BoolDecoration : public ParameterDecoration
 {
 public:
-	BoolDecoration(BoolValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	BoolDecoration(BoolValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~BoolDecoration() {}
 };
 
 class IntDecoration : public ParameterDecoration
 {
 public:
-	IntDecoration(IntValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	IntDecoration(IntValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~IntDecoration() {}
 };
 
 class FloatDecoration : public ParameterDecoration
 {
 public:
-	FloatDecoration(FloatValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	FloatDecoration(FloatValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~FloatDecoration() {}
 };
 
 class StringDecoration : public ParameterDecoration
 {
 public:
-	StringDecoration(StringValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	StringDecoration(StringValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~StringDecoration() {}
 };
 
 class Matrix44fDecoration : public ParameterDecoration
 {
 public:
-	Matrix44fDecoration(Matrix44fValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	Matrix44fDecoration(Matrix44fValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~Matrix44fDecoration() {}
 };
 
 class Point3fDecoration : public ParameterDecoration
 {
 public:
-	Point3fDecoration(Point3fValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	Point3fDecoration(Point3fValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~Point3fDecoration() {}
 };
 
 class ShotfDecoration : public ParameterDecoration
 {
 public:
-	ShotfDecoration(ShotfValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	ShotfDecoration(ShotfValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~ShotfDecoration() {}
 };
 
 class ColorDecoration : public ParameterDecoration
 {
 public:
-	ColorDecoration(ColorValue* defvalue, const QString desc = QString(), const QString tltip = QString());
+	ColorDecoration(ColorValue* defvalue, const QString& desc = QString(), const QString& tltip = QString());
 	~ColorDecoration() {}
 };
 
 class AbsPercDecoration : public ParameterDecoration
 {
 public:
-	AbsPercDecoration(AbsPercValue* defvalue, const float minVal, const float maxVal, const QString desc = QString(), const QString tltip = QString());
+	AbsPercDecoration(AbsPercValue* defvalue, const float minVal, const float maxVal, const QString& desc = QString(), const QString& tltip = QString());
 	float min;
 	float max;
 	~AbsPercDecoration() {}
@@ -406,7 +406,7 @@ public:
 class EnumDecoration : public ParameterDecoration
 {
 public:
-	EnumDecoration(EnumValue* defvalue, QStringList values, const QString desc = QString(), const QString tltip = QString());
+	EnumDecoration(EnumValue* defvalue, QStringList values, const QString& desc = QString(), const QString& tltip = QString());
 	QStringList enumvalues;
 	~EnumDecoration() {}
 };
@@ -422,7 +422,7 @@ public:
 class DynamicFloatDecoration : public ParameterDecoration
 {
 public:
-	DynamicFloatDecoration(DynamicFloatValue* defvalue, const float minVal, const float maxVal, const QString desc = QString(), const QString tltip = QString());
+	DynamicFloatDecoration(DynamicFloatValue* defvalue, const float minVal, const float maxVal, const QString& desc = QString(), const QString& tltip = QString());
 	~DynamicFloatDecoration() {};
 	float min;
 	float max;
@@ -431,7 +431,7 @@ public:
 class SaveFileDecoration : public ParameterDecoration
 {
 public:
-	SaveFileDecoration(FileValue* defvalue, const QString extension, const QString desc = QString(), const QString tltip = QString());
+	SaveFileDecoration(FileValue* defvalue, const QString& extension, const QString& desc = QString(), const QString& tltip = QString());
 	~SaveFileDecoration() {}
 
 	QString ext;
@@ -440,7 +440,7 @@ public:
 class OpenFileDecoration : public ParameterDecoration
 {
 public:
-	OpenFileDecoration(FileValue* directorydefvalue, const QStringList extensions, const QString desc = QString(), const QString tltip = QString());
+	OpenFileDecoration(FileValue* directorydefvalue, const QStringList& extensions, const QString& desc = QString(), const QString& tltip = QString());
 	~OpenFileDecoration() {}
 
 	QStringList exts;
@@ -450,12 +450,12 @@ public:
 class MeshDecoration : public ParameterDecoration
 {
 public:
-	MeshDecoration(MeshValue* defvalue, MeshDocument* doc, const QString desc = QString(), const QString tltip = QString());
+	MeshDecoration(MeshValue* defvalue, MeshDocument* doc, const QString& desc = QString(), const QString& tltip = QString());
 
-	MeshDecoration(int meshind, MeshDocument* doc, const QString desc = QString(), const QString tltip = QString());
+	MeshDecoration(int meshind, MeshDocument* doc, const QString& desc = QString(), const QString& tltip = QString());
 
 	//WARNING: IT SHOULD BE USED ONLY BY MESHLABSERVER!!!!!!!
-	MeshDecoration(int meshind, const QString desc = QString(), const QString tltip = QString());
+	MeshDecoration(int meshind, const QString& desc = QString(), const QString& tooltip = QString());
 
 	~MeshDecoration() {}
 
@@ -513,7 +513,7 @@ public:
 
 	ParameterDecoration* pd;
 
-	RichParameter(const QString nm, Value* v, ParameterDecoration* prdec, bool isxmlpar = false);
+	RichParameter(const QString& nm, Value* v, ParameterDecoration* prdec, bool isxmlpar = false);
 	virtual void accept(Visitor& v) = 0;
 	virtual bool operator==(const RichParameter& rp) = 0;
 	virtual ~RichParameter();
@@ -531,8 +531,8 @@ class RichBool : public RichParameter
 public:
 	RichBool(const QString nm, const bool defval);
 	RichBool(const QString nm, const bool defval, const QString desc);
-	RichBool(const QString nm, const bool defval, const QString desc, const QString tltip);
-	RichBool(const QString nm, const bool val, const bool defval, const QString desc, const QString tltip, bool isxmlpar = false);
+	RichBool(const QString& nm, const bool defval, const QString& desc, const QString& tltip);
+	RichBool(const QString& nm, const bool val, const bool defval, const QString& desc, const QString& tltip, bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 
@@ -542,8 +542,8 @@ public:
 class RichInt : public RichParameter
 {
 public:
-	RichInt(const QString nm, const int defval, const QString desc = QString(), const QString tltip = QString());
-	RichInt(const QString nm, const int val, const int defval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichInt(const QString& nm, const int defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichInt(const QString& nm, const int val, const int defval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichInt();
@@ -552,8 +552,8 @@ public:
 class RichFloat : public RichParameter
 {
 public:
-	RichFloat(const QString nm, const float defval, const QString desc = QString(), const QString tltip = QString());
-	RichFloat(const QString nm, const float val, const float defval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichFloat(const QString& nm, const float defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichFloat(const QString& nm, const float val, const float defval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichFloat();
@@ -562,10 +562,10 @@ public:
 class RichString : public RichParameter
 {
 public:
-	RichString(const QString nm, const QString defval, const QString desc, const QString tltip);
-	RichString(const QString nm, const QString defval);
-	RichString(const QString nm, const QString defval, const QString desc);
-	RichString(const QString nm, const QString val, const QString defval, const QString desc, const QString tltip, bool isxmlpar = false);
+	RichString(const QString& nm, const QString& defval, const QString& desc, const QString& tltip);
+	RichString(const QString& nm, const QString& defval);
+	RichString(const QString& nm, const QString& defval, const QString& desc);
+	RichString(const QString& nm, const QString& val, const QString& defval, const QString& desc, const QString& tltip, bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichString();
@@ -574,9 +574,9 @@ public:
 class RichMatrix44f : public RichParameter
 {
 public:
-	RichMatrix44f(const QString nm, const vcg::Matrix44f& defval, const QString desc = QString(), const QString tltip = QString());
-	RichMatrix44f(const QString nm, const vcg::Matrix44d& defval, const QString desc = QString(), const QString tltip = QString());
-	RichMatrix44f(const QString nm, const vcg::Matrix44f& val, const vcg::Matrix44f& defval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichMatrix44f(const QString& nm, const vcg::Matrix44f& defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichMatrix44f(const QString& nm, const vcg::Matrix44d& defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichMatrix44f(const QString& nm, const vcg::Matrix44f& val, const vcg::Matrix44f& defval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichMatrix44f();
@@ -585,9 +585,9 @@ public:
 class RichPoint3f : public RichParameter
 {
 public:
-	RichPoint3f(const QString nm, const vcg::Point3f defval, const QString desc = QString(), const QString tltip = QString());
-	RichPoint3f(const QString nm, const vcg::Point3d defval, const QString desc = QString(), const QString tltip = QString());
-	RichPoint3f(const QString nm, const vcg::Point3f val, const vcg::Point3f defval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichPoint3f(const QString& nm, const vcg::Point3f& defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichPoint3f(const QString& nm, const vcg::Point3d& defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichPoint3f(const QString& nm, const vcg::Point3f& val, const vcg::Point3f& defval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichPoint3f();
@@ -595,8 +595,8 @@ public:
 class RichShotf : public RichParameter
 {
 public:
-	RichShotf(const QString nm, const vcg::Shotf defval, const QString desc = QString(), const QString tltip = QString());
-	RichShotf(const QString nm, const vcg::Shotf val, const vcg::Shotf defval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichShotf(const QString& nm, const vcg::Shotf& defval, const QString& desc = QString(), const QString& tltip = QString());
+	RichShotf(const QString& nm, const vcg::Shotf& val, const vcg::Shotf& defval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichShotf();
@@ -605,10 +605,10 @@ public:
 class RichColor : public RichParameter
 {
 public:
-	RichColor(const QString nm, const QColor defval);
-	RichColor(const QString nm, const QColor defval, const QString desc);
-	RichColor(const QString nm, const QColor defval, const QString desc, const QString tltip);
-	RichColor(const QString nm, const QColor val, const QColor defval, const QString desc, const QString tltip, bool isxmlpar = false);
+	RichColor(const QString& nm, const QColor& defval);
+	RichColor(const QString& nm, const QColor& defval, const QString& desc);
+	RichColor(const QString& nm, const QColor& defval, const QString& desc, const QString& tltip);
+	RichColor(const QString& nm, const QColor& val, const QColor& defval, const QString& desc, const QString& tltip, bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichColor();
@@ -618,8 +618,8 @@ public:
 class RichAbsPerc : public RichParameter
 {
 public:
-	RichAbsPerc(const QString nm, const float defval, const float minval, const float maxval, const QString desc = QString(), const QString tltip = QString());
-	RichAbsPerc(const QString nm, const float val, const float defval, const float minval, const float maxval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichAbsPerc(const QString& nm, const float defval, const float minval, const float maxval, const QString& desc = QString(), const QString& tltip = QString());
+	RichAbsPerc(const QString& nm, const float val, const float defval, const float minval, const float maxval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichAbsPerc();
@@ -628,8 +628,8 @@ public:
 class RichEnum : public RichParameter
 {
 public:
-	RichEnum(const QString nm, const int defval, const QStringList values, const QString desc = QString(), const QString tltip = QString());
-	RichEnum(const QString nm, const int val, const int defval, const QStringList values, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichEnum(const QString& nm, const int defval, const QStringList& values, const QString& desc = QString(), const QString& tltip = QString());
+	RichEnum(const QString& nm, const int val, const int defval, const QStringList& values, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichEnum();
@@ -642,14 +642,14 @@ public:
 	//lastCreated = new RichMesh(pd.name, pd.val->getMesh(), dec->defVal->getMesh(), dec->meshdoc, dec->fieldDesc, dec->tooltip, pd.isDerivedFromXMLParam());
 	//else
 	//	lastCreated = new RichMesh(pd.name, dec->meshindex, pd.isDerivedFromXMLParam());
-	RichMesh(const QString nm, MeshModel* defval, MeshDocument* doc, const QString desc = QString(), const QString tltip = QString());
-	RichMesh(const QString nm, MeshModel* val, MeshModel* defval, MeshDocument* doc, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichMesh(const QString& nm, MeshModel* defval, MeshDocument* doc, const QString& desc = QString(), const QString& tltip = QString());
+	RichMesh(const QString& nm, MeshModel* val, MeshModel* defval, MeshDocument* doc, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 
-	RichMesh(const QString nm, int meshindex, MeshDocument* doc, const QString desc = QString(), const QString tltip = QString());
+	RichMesh(const QString& nm, int meshindex, MeshDocument* doc, const QString& desc = QString(), const QString& tltip = QString());
 
 	//WARNING: IT SHOULD BE USED ONLY BY MESHLABSERVER!!!!!!!
-	RichMesh(const QString nm, int meshind, bool isxmlpar = false);
-	RichMesh(const QString nm, int meshind, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichMesh(const QString& nm, int meshind, bool isxmlpar = false);
+	RichMesh(const QString& nm, int meshind, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
@@ -661,8 +661,8 @@ public:
 class RichFloatList : public RichParameter
 {
 public:
-	RichFloatList(const QString nm, FloatListValue* v, FloatListDecoration* prdec);
-	RichFloatList(const QString nm, FloatListValue* val, FloatListValue* v, FloatListDecoration* prdec, bool isxmlpar = false);
+	RichFloatList(const QString& nm, FloatListValue* v, FloatListDecoration* prdec);
+	RichFloatList(const QString& nm, FloatListValue* val, FloatListValue* v, FloatListDecoration* prdec, bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichFloatList();
@@ -671,8 +671,8 @@ public:
 class RichDynamicFloat : public RichParameter
 {
 public:
-	RichDynamicFloat(const QString nm, const float defval, const float minval, const float maxval, const QString desc = QString(), const QString tltip = QString());
-	RichDynamicFloat(const QString nm, const float val, const float defval, const float minval, const float maxval, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichDynamicFloat(const QString& nm, const float defval, const float minval, const float maxval, const QString& desc = QString(), const QString& tltip = QString());
+	RichDynamicFloat(const QString& nm, const float val, const float defval, const float minval, const float maxval, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichDynamicFloat();
@@ -682,7 +682,7 @@ public:
 class RichOpenFile : public RichParameter
 {
 public:
-	RichOpenFile(const QString nm, const QString directorydefval, const QStringList exts, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichOpenFile(const QString& nm, const QString& directorydefval, const QStringList& exts, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichOpenFile();
@@ -691,7 +691,7 @@ public:
 class RichSaveFile : public RichParameter
 {
 public:
-	RichSaveFile(const QString nm, const QString filedefval, const QString ext, const QString desc = QString(), const QString tltip = QString(), bool isxmlpar = false);
+	RichSaveFile(const QString& nm, const QString& filedefval, const QString& ext, const QString& desc = QString(), const QString& tltip = QString(), bool isxmlpar = false);
 	void accept(Visitor& v);
 	bool operator==(const RichParameter& rb);
 	~RichSaveFile();
@@ -812,9 +812,8 @@ public:
 	//QMap<QString, FilterParameter *> paramMap;
 	QList<RichParameter*> paramList;
 	bool isEmpty() const;
-	//RichParameter* findParameter(QString name);
-	RichParameter* findParameter(QString name) const;
-	bool hasParameter(QString name) const;
+	RichParameter* findParameter(const QString& name) const;
+	bool hasParameter(const QString& name) const;
 
 
 	RichParameterSet& operator=(const RichParameterSet& rps);
@@ -825,31 +824,31 @@ public:
 	RichParameterSet& addParam(RichParameter* pd);
 
 	//remove a parameter from the set by name
-	RichParameterSet& removeParameter(QString name);
+	RichParameterSet& removeParameter(const QString& name);
 
 	void clear();
 
-	void setValue(const QString name, const Value& val);
+	void setValue(const QString& name, const Value& val);
 
-	bool				getBool(QString name) const;
-	int					getInt(QString name) const;
-	float				getFloat(QString name) const;
-	QString			getString(QString name) const;
-	vcg::Matrix44f		getMatrix44(QString name) const;
-	vcg::Matrix44<MESHLAB_SCALAR>		getMatrix44m(QString name) const;
-	vcg::Point3f getPoint3f(QString name) const;
-	vcg::Point3<MESHLAB_SCALAR> getPoint3m(QString name) const;
-	vcg::Shotf getShotf(QString name) const;
-	vcg::Shot<MESHLAB_SCALAR> getShotm(QString name) const;
-	QColor		   getColor(QString name) const;
-	vcg::Color4b getColor4b(QString name) const;
-	float		     getAbsPerc(QString name) const;
-	int					 getEnum(QString name) const;
-	MeshModel*   getMesh(QString name) const;
-	QList<float> getFloatList(QString name) const;
-	float        getDynamicFloat(QString name) const;
-	QString getOpenFileName(QString name) const;
-	QString getSaveFileName(QString name) const;
+	bool				getBool(const QString& name) const;
+	int					getInt(const QString& name) const;
+	float				getFloat(const QString& name) const;
+	QString			getString(const QString& name) const;
+	vcg::Matrix44f		getMatrix44(const QString& name) const;
+	vcg::Matrix44<MESHLAB_SCALAR>		getMatrix44m(const QString& name) const;
+	vcg::Point3f getPoint3f(const QString& name) const;
+	vcg::Point3<MESHLAB_SCALAR> getPoint3m(const QString& name) const;
+	vcg::Shotf getShotf(const QString& name) const;
+	vcg::Shot<MESHLAB_SCALAR> getShotm(const QString& name) const;
+	QColor		   getColor(const QString& name) const;
+	vcg::Color4b getColor4b(const QString& name) const;
+	float		     getAbsPerc(const QString& name) const;
+	int					 getEnum(const QString& name) const;
+	MeshModel*   getMesh(const QString& name) const;
+	QList<float> getFloatList(const QString& name) const;
+	float        getDynamicFloat(const QString& name) const;
+	QString getOpenFileName(const QString& name) const;
+	QString getSaveFileName(const QString& name) const;
 
 
 	~RichParameterSet();

--- a/src/common/meshmodel.h
+++ b/src/common/meshmodel.h
@@ -128,7 +128,7 @@ public:
         MM_ALL				= 0xffffffff
     };
 
-    MeshModel(MeshDocument *parent, QString fullFileName, QString labelName);
+    MeshModel(MeshDocument *parent, const QString& fullFileName, const QString& labelName);
 	MeshModel(MeshModel* cp);
     ~MeshModel()
     {
@@ -268,7 +268,7 @@ public:
     const QString shortName() const { return QFileInfo(fullPathFileName).fileName(); }
 
     Plane(const Plane& pl);
-    Plane(const QString pathName, const int _semantic);
+    Plane(const QString& pathName, const int _semantic);
 
 }; //end class Plane
 
@@ -484,8 +484,8 @@ public:
 
     /// returns the mesh with the given unique id
     MeshModel *getMesh(int id);
-    MeshModel *getMesh(QString name);
-    MeshModel *getMeshByFullName(QString pathName);
+    MeshModel *getMesh(const QString& name);
+    MeshModel *getMeshByFullName(const QString& pathName);
 
 
     //set the current mesh to be the one with the given ID
@@ -607,7 +607,7 @@ private:
 public:
     ///add a new mesh with the given name
     MeshModel *addNewMesh(QString fullPath, QString Label, bool setAsCurrent=true);
-    MeshModel *addOrGetMesh(QString fullPath, QString Label, bool setAsCurrent=true);
+    MeshModel *addOrGetMesh(QString fullPath, const QString& Label, bool setAsCurrent=true);
     
 
     ///remove the mesh from the list and delete it from memory

--- a/src/common/pluginmanager.cpp
+++ b/src/common/pluginmanager.cpp
@@ -190,7 +190,7 @@ void PluginManager::loadPlugins(RichParameterSet& defaultGlobal)
 }
 
 // Search among all the decorator plugins the one that contains a decoration with the given name
-MeshDecorateInterface *PluginManager::getDecoratorInterfaceByName(QString name)
+MeshDecorateInterface *PluginManager::getDecoratorInterfaceByName(const QString& name)
 {
   foreach(MeshDecorateInterface *tt, this->meshDecoratePlugins())
   {

--- a/src/common/pluginmanager.h
+++ b/src/common/pluginmanager.h
@@ -64,7 +64,7 @@ public:
 
     QMap<QString,RichParameterSet> generateFilterParameterMap();
 
-    MeshDecorateInterface* getDecoratorInterfaceByName(QString name);
+    MeshDecorateInterface* getDecoratorInterfaceByName(const QString& name);
 
     QDir pluginsDir;
     QMap<QString, QAction*> actionFilterMap;

--- a/src/common/scriptinterface.cpp
+++ b/src/common/scriptinterface.cpp
@@ -719,7 +719,7 @@ QColor EnvWrap::evalColor(const QString& nm)
 			if (!isScalarInt)
 				throw ExpressionHasNotThisTypeException("Color", nm);
 			else
-				if ((resInt < 0) && (resInt > 255))
+				if ((resInt < 0) || (resInt > 255))
 					isInt0255 = false;
 		}
 		if (isInt0255)

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -400,7 +400,7 @@ void MainWindow::updateMenus()
     lastFilterAct->setText(QString("Apply filter"));
     editMenu->setEnabled(!editMenu->actions().isEmpty());
     updateMenuItems(editMenu,activeDoc);
-    renderMenu->setEnabled(!editMenu->actions().isEmpty());
+    renderMenu->setEnabled(!renderMenu->actions().isEmpty());
     updateMenuItems(renderMenu,activeDoc);
     fullScreenAct->setEnabled(activeDoc);
 	showLayerDlgAct->setEnabled(activeDoc);

--- a/src/meshlab/plugindialog.cpp
+++ b/src/meshlab/plugindialog.cpp
@@ -84,6 +84,16 @@ PluginDialog::PluginDialog(const QString &path, const QStringList &fileNames,QWi
         pathDirectory=path;
 }
 
+static QString computeXmlFilename(const QDir & dir, const QString & filename)
+{
+    QFileInfo f(dir.absoluteFilePath(filename));
+    QString tmp = f.baseName() + ".xml";
+    if (tmp.startsWith("lib")) {
+        tmp.replace("lib", "");
+    }
+    return dir.absoluteFilePath(tmp);
+}
+
 void PluginDialog::populateTreeWidget(const QString &path,const QStringList &fileNames)
 {
     if (fileNames.isEmpty()) {
@@ -136,9 +146,7 @@ void PluginDialog::populateTreeWidget(const QString &path,const QStringList &fil
                                 MeshLabFilterInterface *iXMLFilter = qobject_cast<MeshLabFilterInterface *>(plugin);
                                 if (iXMLFilter)
                                 {
-                                    QFileInfo f(dir.absoluteFilePath(fileName));
-                                    QString tmp = f.baseName() + ".xml";
-                                    QString xmlFile = dir.absoluteFilePath(tmp);
+                                    QString xmlFile = computeXmlFilename(dir, fileName);
                                     XMLMessageHandler xmlErr;
                                     MeshLabXMLFilterContainer fc;
                                     fc.xmlInfo = MLXMLPluginInfo::createXMLPluginInfo(xmlFile,MLXMLUtilityFunctions::xmlSchemaFile(),xmlErr);
@@ -219,9 +227,7 @@ void PluginDialog::displayInfo(QTreeWidgetItem* item,int /* ncolumn*/)
         MeshLabFilterInterface *iXMLFilter = qobject_cast<MeshLabFilterInterface *>(plugin);
         if (iXMLFilter)
         {
-            QFileInfo f(dir.absoluteFilePath(parent));
-            QString tmp = f.baseName() + ".xml";
-            QString xmlFile = dir.absoluteFilePath(tmp);
+            QString xmlFile = computeXmlFilename(dir, parent);
             XMLMessageHandler xmlErr;
             MeshLabXMLFilterContainer fc;
             fc.xmlInfo = MLXMLPluginInfo::createXMLPluginInfo(xmlFile,MLXMLUtilityFunctions::xmlSchemaFile(),xmlErr);

--- a/src/meshlabplugins/edit_mutualcorrs/solver.cpp
+++ b/src/meshlabplugins/edit_mutualcorrs/solver.cpp
@@ -315,7 +315,7 @@ int Solver::levmar(AlignSet *_align, MutualInfo *_mutual, Shot &shot) {
 //			corrTsai->point2d = currentPoint2d;
 //		}
 //        qDebug("Point3d %f %f %f",(float)corrTsai->point3d.X(),(float)corrTsai->point3d.Y(),(float)(float)corrTsai->point3d.Z());
-//        qDebug("Point2d %f %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
+//        qDebug("Point2d %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
 //
 //        corrs->push_back(*corrTsai);
 //    }
@@ -460,7 +460,7 @@ bool Solver::levmar(AlignSet *_align, Shot &shot){
 		corrLevmar->point2d = vcg::Point2d(align->correspList[i].Point2D.X(), align->correspList[i].Point2D.Y());
 
         qDebug("Point3d %f %f %f",(float)corrLevmar->point3d.X(),(float)corrLevmar->point3d.Y(),(float)(float)corrLevmar->point3d.Z());
-        qDebug("Point2d %f %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
+        qDebug("Point2d %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
 
         corrs->push_back(*corrLevmar);
     }

--- a/src/meshlabplugins/edit_paint/edit_paint.cpp
+++ b/src/meshlabplugins/edit_paint/edit_paint.cpp
@@ -1342,7 +1342,7 @@ void drawPercentualPolyLine(GLArea * gla, QPoint &mid, MeshModel &m, GLfloat* pi
 			da = da / 2.0;
 			db = db / 2.0;
 			dc = dc / 2.0;
-			if (fabsf(zz - pix_z) < 0.001)
+			if (std::abs(zz - pix_z) < 0.001)
 			{
 				proj_points[i] = QPointF(pix_x, inv_yy);
 				break;

--- a/src/meshlabplugins/edit_paint/edit_paint.h
+++ b/src/meshlabplugins/edit_paint/edit_paint.h
@@ -332,16 +332,17 @@ inline void fastMultiply(float x, float y, float z, double matrix[], double *xr,
  */
 inline int getNearest(QPointF center, QPointF *points, int num)
 {
+	using std::abs;
 	int index = 0;
 
-	float dist = fabsf(center.x() - points[0].x())*fabsf(center.x() - points[0].x()) + fabsf(center.y() - points[0].y())*fabsf(center.y() - points[0].y());
+	float dist = abs(center.x() - points[0].x())*abs(center.x() - points[0].x()) + abs(center.y() - points[0].y())*abs(center.y() - points[0].y());
 
 	float temp = 0;
 
 	for (int i = 1; i < num; i++)
 	{
-		temp = fabsf(center.x() - points[i].x())*fabsf(center.x() - points[i].x()) +
-			fabsf(center.y() - points[i].y())*fabsf(center.y() - points[i].y());
+		temp = abs(center.x() - points[i].x())*abs(center.x() - points[i].x()) +
+			abs(center.y() - points[i].y())*abs(center.y() - points[i].y());
 
 		if (temp < dist) {
 			index = i;

--- a/src/meshlabplugins/edit_point/edit_point_factory.cpp
+++ b/src/meshlabplugins/edit_point/edit_point_factory.cpp
@@ -51,6 +51,7 @@ MeshEditInterface* PointEditFactory::getMeshEditInterface(QAction *action)
             return new EditPointPlugin(EditPointPlugin::SELECT_FITTING_PLANE_MODE);
 
         assert(0); //should never be asked for an action that isn't here
+        return nullptr;
 }
 
 QString PointEditFactory::getEditToolDescription(QAction *)

--- a/src/meshlabplugins/edit_quality/edit_quality_factory.cpp
+++ b/src/meshlabplugins/edit_quality/edit_quality_factory.cpp
@@ -48,6 +48,7 @@ MeshEditInterface* QualityMapperFactory::getMeshEditInterface(QAction *action)
 	{
 		return new QualityMapperPlugin();
 	} else assert(0); //should never be asked for an action that isnt here
+	return nullptr;
 }
 
 QString QualityMapperFactory::getEditToolDescription(QAction *)

--- a/src/meshlabplugins/edit_quality/qualitymapperdialog.cpp
+++ b/src/meshlabplugins/edit_quality/qualitymapperdialog.cpp
@@ -1211,7 +1211,7 @@ void QualityMapperDialog::on_resetButton_clicked()
 // Method invoked when moving left/right EqHandles. It calls drawEqualizerHistogram with the correct parameters
 void QualityMapperDialog::on_EqHandle_crossing_histogram(EqHandle* sender, bool insideHistogram)
 {
-	if (sender = _equalizerHandles[LEFT_HANDLE])
+	if (sender == _equalizerHandles[LEFT_HANDLE])
 		drawEqualizerHistogram(insideHistogram, _rightHandleWasInsideHistogram);
 	else
 		drawEqualizerHistogram(_leftHandleWasInsideHistogram, insideHistogram);

--- a/src/meshlabplugins/edit_quality/qualitymapperdialog.h
+++ b/src/meshlabplugins/edit_quality/qualitymapperdialog.h
@@ -77,6 +77,7 @@ class TFDoubleClickCatcher : public QObject, public QGraphicsItem
 {
 	Q_OBJECT
 
+	Q_INTERFACES(QGraphicsItem)
 private:
 	CHART_INFO		*_environmentInfo;
 	QGraphicsView	*_myView;

--- a/src/meshlabplugins/edit_referencing/edit_referencing.cpp
+++ b/src/meshlabplugins/edit_referencing/edit_referencing.cpp
@@ -866,7 +866,7 @@ void EditReferencingPlugin::updateDistances()
 		{
 			scaleFact[dindex] = targDist[dindex] / currDist[dindex];
 
-			if ((useDistance[dindex]) && (!scaleFact[dindex] == 0.0))
+			if ((useDistance[dindex]) && (scaleFact[dindex] != 0.0))
 			{
 				curr_scale += scaleFact[dindex];
 				numValid++;

--- a/src/meshlabplugins/edit_referencing/edit_referencing_factory.cpp
+++ b/src/meshlabplugins/edit_referencing/edit_referencing_factory.cpp
@@ -47,6 +47,7 @@ MeshEditInterface* EditReferencingFactory::getMeshEditInterface(QAction *action)
 	{
         return new EditReferencingPlugin();
 	} else assert(0); //should never be asked for an action that isnt here
+    return nullptr;
 }
 
 QString EditReferencingFactory::getEditToolDescription(QAction *)

--- a/src/meshlabplugins/edit_select/edit_select_factory.cpp
+++ b/src/meshlabplugins/edit_select/edit_select_factory.cpp
@@ -59,6 +59,7 @@ MeshEditInterface* EditSelectFactory::getMeshEditInterface(QAction *action)
 		return new EditSelectPlugin(EditSelectPlugin::SELECT_AREA_MODE);
 
 	assert(0); //should never be asked for an action that isnt here
+	return nullptr;
 }
 
 QString EditSelectFactory::getEditToolDescription(QAction * /*a*/)

--- a/src/meshlabplugins/filter_camera/filter_camera.cpp
+++ b/src/meshlabplugins/filter_camera/filter_camera.cpp
@@ -739,7 +739,7 @@ int FilterCameraPlugin::getPreConditions( QAction * a) const
 		return MeshModel::MM_VERTNORMAL;
 	}
 	assert(0);
-	return NULL;
+	return 0;
 }
 
 MeshFilterInterface::FILTER_ARITY FilterCameraPlugin::filterArity( QAction* act ) const

--- a/src/meshlabplugins/filter_clean/align_tools.cpp
+++ b/src/meshlabplugins/filter_clean/align_tools.cpp
@@ -21,20 +21,20 @@
 *                                                                           *
 ****************************************************************************/
 
-#include <QtGui>
 
 #include "align_tools.h"
 
-#include <meshlabplugins/edit_pickpoints/pickedPoints.h>
+#include "../edit_pickpoints/pickedPoints.h"
+#include "../edit_align/align/align_parameter.h"
+#include "../edit_align/meshtree.h"
+#include "../edit_align/align/AlignPair.h"
 
-#include <meshlabplugins/editalign/align/align_parameter.h>
-#include <meshlabplugins/editalign/meshtree.h>
-#include <meshlabplugins/editalign/align/AlignPair.h>
-
-#include <vcg/math/point_matching.h>
+#include <vcg/space/point_matching.h>
 
 #include <vcg/complex/algorithms/update/position.h>
 #include <vcg/complex/algorithms/update/bounding.h>
+
+#include <QtGui>
 
 using namespace vcg;
 

--- a/src/meshlabplugins/filter_color_projection/filter_color_projection.cpp
+++ b/src/meshlabplugins/filter_color_projection/filter_color_projection.cpp
@@ -256,7 +256,10 @@ bool FilterColorProjectionPlugin::applyFilter(QAction *filter, MeshDocument &md,
                 // init rendermanager
                 rendermanager = new RenderHelper();
                 if( rendermanager->initializeGL(cb) != 0 )
+                {
+                    delete rendermanager;
                     return false;
+                }
                 Log("init GL");
                 //if( rendermanager->initializeMeshBuffers(model, cb) != 0 )
                 //    return false;

--- a/src/meshlabplugins/filter_color_projection/render_helper.h
+++ b/src/meshlabplugins/filter_color_projection/render_helper.h
@@ -30,6 +30,8 @@
 #include <wrap/gl/shot.h>
 #include <wrap/callback.h>
 
+#include "floatbuffer.h"
+
 class QGLFramebufferObject;
 
 class RenderHelper {

--- a/src/meshlabplugins/filter_isoparametrization/mesh_operators.h
+++ b/src/meshlabplugins/filter_isoparametrization/mesh_operators.h
@@ -713,7 +713,7 @@ inline void getAroundFaceVertices(typename MeshType::VertexType *v0,
     }
 
     ///get all vertices around the collapse
-    for (int i=0;i<in_v0.size();i++)
+    for (int i=0;i<in_v1.size();i++)
     {
         for (int j=0;j<3;j++)
             if ((in_v1[i].V(j)!=v0)&&(in_v1[i].V(j)!=v1))

--- a/src/meshlabplugins/filter_meshing/meshfilter.cpp
+++ b/src/meshlabplugins/filter_meshing/meshfilter.cpp
@@ -636,7 +636,7 @@ void ApplyTransform(MeshDocument &md, const Matrix44m &tr, bool toAllFlag, bool 
   if(toAllFlag)
   {
     MeshModel   *m=NULL;    
-    while (m=md.nextVisibleMesh(m))
+    while ((m=md.nextVisibleMesh(m)))
     {
       if(invertFlag) m->cm.Tr = Inverse(m->cm.Tr);
       if(composeFlage) m->cm.Tr = tr * m->cm.Tr;

--- a/src/meshlabplugins/filter_mutualglobal/alignGlobal.h
+++ b/src/meshlabplugins/filter_mutualglobal/alignGlobal.h
@@ -30,8 +30,8 @@ Revision 1.1  2006/09/25 09:24:39  e_cerisoli
 add sampleplugins
 
 ****************************************************************************/
-
-
+#ifndef ALIGNGLOBAL_H
+#define ALIGNGLOBAL_H
 
 #include <common/interfaces.h>
 
@@ -101,3 +101,5 @@ public:
 
 //std::vector<SubGraph*> graphs;
 
+
+#endif // ALIGNGLOBAL_H

--- a/src/meshlabplugins/filter_mutualglobal/solver.cpp
+++ b/src/meshlabplugins/filter_mutualglobal/solver.cpp
@@ -564,7 +564,7 @@ int Solver::levmar(AlignSet *_align, MutualInfo *_mutual, Shot &shot) {
 //			corrTsai->point2d = currentPoint2d;
 //		}
 //        qDebug("Point3d %f %f %f",(float)corrTsai->point3d.X(),(float)corrTsai->point3d.Y(),(float)(float)corrTsai->point3d.Z());
-//        qDebug("Point2d %f %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
+//        qDebug("Point2d %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
 //
 //        corrs->push_back(*corrTsai);
 //    }
@@ -738,7 +738,7 @@ bool Solver::levmar(AlignSet *_align, Shot &shot){
 			corrLevmar->point2d = currentPoint2d;
 		}
 		qDebug("Point3d %f %f %f",(float)corrLevmar->point3d.X(),(float)corrLevmar->point3d.Y(),(float)(float)corrLevmar->point3d.Z());
-		qDebug("Point2d %f %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
+		qDebug("Point2d %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
 
 		corrs->push_back(*corrLevmar);
 	}

--- a/src/meshlabplugins/filter_mutualinfoxml/solver.cpp
+++ b/src/meshlabplugins/filter_mutualinfoxml/solver.cpp
@@ -432,7 +432,7 @@ int Solver::levmar(AlignSet *_align, MutualInfo *_mutual, Shot &shot) {
   align->shot = p.toShot();
 
   delete []x;
-  delete _p;
+  delete []_p;
 
 
   return niter;

--- a/src/meshlabplugins/filter_mutualinfoxml/solver.cpp
+++ b/src/meshlabplugins/filter_mutualinfoxml/solver.cpp
@@ -463,7 +463,7 @@ int Solver::levmar(AlignSet *_align, MutualInfo *_mutual, Shot &shot) {
 //			corrTsai->point2d = currentPoint2d;
 //		}
 //        qDebug("Point3d %f %f %f",(float)corrTsai->point3d.X(),(float)corrTsai->point3d.Y(),(float)(float)corrTsai->point3d.Z());
-//        qDebug("Point2d %f %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
+//        qDebug("Point2d %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
 //
 //        corrs->push_back(*corrTsai);
 //    }
@@ -635,7 +635,7 @@ bool Solver::levmar(AlignSet *_align, Shot &shot){
             corrLevmar->point2d = currentPoint2d;
         }
         qDebug("Point3d %f %f %f",(float)corrLevmar->point3d.X(),(float)corrLevmar->point3d.Y(),(float)(float)corrLevmar->point3d.Z());
-        qDebug("Point2d %f %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
+        qDebug("Point2d %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
 
         corrs->push_back(*corrLevmar);
     }

--- a/src/meshlabplugins/filter_screened_poisson/Src/MarchingCubes.cpp
+++ b/src/meshlabplugins/filter_screened_poisson/Src/MarchingCubes.cpp
@@ -145,9 +145,9 @@ bool Cube::IsEdgeCorner( int cIndex , int e )
 	FactorEdgeIndex( e , o , i , j );
 	switch( o )
 	{
-	case 0: return (cIndex && 2)==(i<<1) && (cIndex && 4)==(j<<2);
-	case 1: return (cIndex && 1)==(i<<0) && (cIndex && 4)==(j<<2);
-	case 2: return (cIndex && 4)==(i<<2) && (cIndex && 2)==(j<<1);
+	case 0: return (cIndex & 2)==(i<<1) && (cIndex & 4)==(j<<2);
+	case 1: return (cIndex & 1)==(i<<0) && (cIndex & 4)==(j<<2);
+	case 2: return (cIndex & 4)==(i<<2) && (cIndex & 2)==(j<<1);
 	default: return false;
 	}
 }

--- a/src/meshlabplugins/filter_screened_poisson/Src/SparseMatrix.inl
+++ b/src/meshlabplugins/filter_screened_poisson/Src/SparseMatrix.inl
@@ -209,7 +209,7 @@ SparseMatrix<T> SparseMatrix<T>::operator * (const T& V) const
 template<class T>
 SparseMatrix<T>& SparseMatrix<T>::operator *= (const T& V)
 {
-	for( int i=0 ; i<rows ; i++ ) for( int ii=0 ; ii<rowSizes[i] ; i++ ) m_ppElements[i][ii].Value *= V;
+	for( int i=0 ; i<rows ; i++ ) for( int ii=0 ; ii<rowSizes[i] ; ii++ ) m_ppElements[i][ii].Value *= V;
 	return *this;
 }
 

--- a/src/meshlabplugins/filter_select/meshselect.cpp
+++ b/src/meshlabplugins/filter_select/meshselect.cpp
@@ -327,7 +327,7 @@ switch(ID(action))
 		if (par.getBool("allLayers"))
 		{
 			MeshModel   *ml = NULL;
-			while (ml = md.nextVisibleMesh(ml))
+			while ((ml = md.nextVisibleMesh(ml)))
 			{
 				int ffn = ml->cm.fn;
 				for (fi = ml->cm.face.begin(); fi != ml->cm.face.end(); ++fi)

--- a/src/meshlabplugins/filter_texture/filter_texture.cpp
+++ b/src/meshlabplugins/filter_texture/filter_texture.cpp
@@ -848,7 +848,7 @@ bool FilterTexturePlugin::applyFilter(QAction *filter, MeshDocument &md, RichPar
 		assert (srcMesh != NULL);
 		assert (trgMesh != NULL);
 		CheckError(!QFile(trgMesh->fullName()).exists(), "Save the target mesh before creating a texture");
-		CheckError(trgMesh->cm.fn == 0 || trgMesh->cm.fn == 0, "Both meshes require to have faces");
+		CheckError(srcMesh->cm.fn == 0 || trgMesh->cm.fn == 0, "Both meshes require to have faces");
 		CheckError(!trgMesh->hasDataMask(MeshModel::MM_WEDGTEXCOORD), "Target mesh doesn't have Per Wedge Texture Coordinates");
 		CheckError(textW <= 0, "Texture Width has an incorrect value");
 		CheckError(textH <= 0, "Texture Height has an incorrect value");

--- a/src/meshlabplugins/filter_trioptimize/filter_trioptimize.cpp
+++ b/src/meshlabplugins/filter_trioptimize/filter_trioptimize.cpp
@@ -130,6 +130,7 @@ TriOptimizePlugin::TriOptimizePlugin()
 		case FP_NEAR_LAPLACIAN_SMOOTH: 	return tr("Laplacian Smooth (surface preserving)");
 		default:		assert(0);
 	}
+	return {};
 }
 
  int TriOptimizePlugin::getRequirements(QAction *action)
@@ -162,6 +163,7 @@ TriOptimizePlugin::TriOptimizePlugin()
 					   "on original surface");
 		default : assert(0);
 	}
+	return {};
 }
 
  TriOptimizePlugin::FilterClass TriOptimizePlugin::getClass(QAction *action)
@@ -183,6 +185,7 @@ int TriOptimizePlugin::postCondition(QAction *a) const
 		case FP_NEAR_LAPLACIAN_SMOOTH : return MeshModel::MM_VERTCOORD | MeshModel::MM_VERTNORMAL;
 		default                       : assert(0);
 	}
+	return {};
 }
 
 // This function define the needed parameters for each filter.

--- a/src/meshlabplugins/io_expe/import_expe.h
+++ b/src/meshlabplugins/io_expe/import_expe.h
@@ -116,7 +116,7 @@ class ImporterExpePTS
 				"No errors", "Can't open file", "Invalid file", "Unsupported version"
 			};
 
-			if(message_code>4 || message_code<0)
+			if(message_code>=4 || message_code<0)
 				return "Unknown error";
 			else
 				return error_msg[message_code];

--- a/src/meshlabplugins/io_expe/import_xyz.h
+++ b/src/meshlabplugins/io_expe/import_xyz.h
@@ -94,7 +94,7 @@ class ImporterXYZ
 				"No errors", "Can't open file", "Invalid file", "Unsupported version"
 			};
 
-			if(message_code>4 || message_code<0)
+			if(message_code>=4 || message_code<0)
 				return "Unknown error";
 			else
 				return error_msg[message_code];

--- a/src/meshlabplugins/io_x3d/vrml/Scanner.cpp
+++ b/src/meshlabplugins/io_x3d/vrml/Scanner.cpp
@@ -417,6 +417,7 @@ Scanner::Scanner(const wchar_t* fileName) {
 	if ((stream = fopen(chFileName, "rb")) == NULL) {
 		char msg[50];
 		sprintf(msg, "Can not open file: %s", chFileName);
+		coco_string_delete(chFileName);
 		throw msg;
 	}
 	coco_string_delete(chFileName);

--- a/src/plugins_unsupported/filter_mutualinfo/solver.cpp
+++ b/src/plugins_unsupported/filter_mutualinfo/solver.cpp
@@ -463,7 +463,7 @@ int Solver::levmar(AlignSet *_align, MutualInfo *_mutual, Shot &shot) {
 //			corrTsai->point2d = currentPoint2d;
 //		}
 //        qDebug("Point3d %f %f %f",(float)corrTsai->point3d.X(),(float)corrTsai->point3d.Y(),(float)(float)corrTsai->point3d.Z());
-//        qDebug("Point2d %f %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
+//        qDebug("Point2d %f %f",(float)corrTsai->point2d.X(),(float)corrTsai->point2d.Y());
 //
 //        corrs->push_back(*corrTsai);
 //    }
@@ -637,7 +637,7 @@ bool Solver::levmar(AlignSet *_align, Shot &shot){
 			corrLevmar->point2d = currentPoint2d;
 		}
 		qDebug("Point3d %f %f %f",(float)corrLevmar->point3d.X(),(float)corrLevmar->point3d.Y(),(float)(float)corrLevmar->point3d.Z());
-		qDebug("Point2d %f %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
+		qDebug("Point2d %f %f",(float)corrLevmar->point2d.X(),(float)corrLevmar->point2d.Y());
 
 		corrs->push_back(*corrLevmar);
 	}

--- a/src/sampleplugins/sampleedit/edit_sample_factory.cpp
+++ b/src/sampleplugins/sampleedit/edit_sample_factory.cpp
@@ -47,6 +47,7 @@ MeshEditInterface* SampleEditFactory::getMeshEditInterface(QAction *action)
 	{
 		return new SampleEditPlugin();
 	} else assert(0); //should never be asked for an action that isnt here
+	return nullptr;
 }
 
 QString SampleEditFactory::getEditToolDescription(QAction *)

--- a/src/sampleplugins/samplefilterdyn/samplefilterdyn.cpp
+++ b/src/sampleplugins/samplefilterdyn/samplefilterdyn.cpp
@@ -50,6 +50,7 @@ QString ExtraSampleDynPlugin::filterName(FilterIDType filterId) const
 		case FP_VERTEX_COLOR_NOISE :  return QString("Vertex Color Noise"); 
 		default : assert(0); 
 	}
+	return {};
 }
 
 // Info() must return the longer string describing each filtering action 
@@ -60,6 +61,7 @@ QString ExtraSampleDynPlugin::filterName(FilterIDType filterId) const
 		case FP_VERTEX_COLOR_NOISE :  return QString("Randomly add a small amount of a random base color to the mesh"); 
 		default : assert(0); 
 	}
+	return {};
 }
 
 // The FilterClass describes in which generic class of filters it fits. 


### PR DESCRIPTION
These are miscellaneous fixes found in the process of setting up the CMake-based build system - though none of these touch the build system at all.

Some of them are warning fixes that are probably harmless, some are warning fixes that indicated a definite error, and some (like the plugin dialog) fix broken functionality. (I assumed that it was the way I was building that kept the plugin dialog from "expanding" the filter plugins, but it turns out it was actually a code defect, now fixed. See screenshot - filter_measure had no text below and no expander in the tree before these patches.)


![Screenshot from 2019-12-03 17-22-34](https://user-images.githubusercontent.com/61129/70098449-90458c00-15f1-11ea-8a76-36d0f1569dd4.png)
 

(Some of these warning fixes, etc. probably duplicate fixes in other PR's that haven't yet been merged.)

cc @jmespadero