### PR TITLE
Linux dirs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ addons:
     - qt512xmlpatterns
     - mesa-common-dev
     - libglu1-mesa-dev
-    - lib3ds-dev
-    - libglew-dev
-    - libeigen3-dev
-    - libopenctm-dev
-    - libbz2-dev
   homebrew:
     packages:
     - llvm
@@ -75,19 +70,7 @@ script:
   - cd ..
   - qmake meshlab_full.pro
   - make -j4
-  # On linux, rebuild using system libs.
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "linux"   ]]; then
-      make clean
-      cd external
-      make clean
-      qmake CONFIG+=system_eigen3 CONFIG+=system_glew CONFIG+=system_lib3ds CONFIG+=system_openctm CONFIG+=system_bzip2
-      make -j4
-      cd ..
-      qmake CONFIG+=system_eigen3 CONFIG+=system_glew CONFIG+=system_lib3ds CONFIG+=system_openctm CONFIG+=system_bzip2 meshlab_full.pro
-      make -j4
-    fi
-      
+
 after_success:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]

--- a/src/common/pluginmanager.cpp
+++ b/src/common/pluginmanager.cpp
@@ -254,11 +254,24 @@ QString PluginManager::getBaseDirPath()
 QString PluginManager::getDefaultPluginDirPath()
 {
 	QDir pluginsDir(getBaseDirPath());
-	if (!pluginsDir.exists("plugins"))
-		//QMessageBox::warning(0,"Meshlab Initialization","Serious error. Unable to find the plugins directory.");
-		qDebug("Meshlab Initialization: Serious error. Unable to find the plugins directory.");
-	pluginsDir.cd("plugins");
-	return pluginsDir.absolutePath();
+	if (pluginsDir.exists("plugins")) {
+		pluginsDir.cd("plugins");
+		return pluginsDir.absolutePath();
+	}
+#if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
+	if (pluginsDir.dirName() == "bin") {
+		pluginsDir.cdUp();
+		pluginsDir.cd("lib");
+		pluginsDir.cd("meshlab");
+		if (pluginsDir.exists("plugins")) {
+			pluginsDir.cd("plugins");
+			return pluginsDir.absolutePath();
+		}
+	}
+#endif
+	//QMessageBox::warning(0,"Meshlab Initialization","Serious error. Unable to find the plugins directory.");
+	qDebug("Meshlab Initialization: Serious error. Unable to find the plugins directory.");
+	return {};
 }
 
 

--- a/src/meshlabplugins/render_gdp/meshrender.cpp
+++ b/src/meshlabplugins/render_gdp/meshrender.cpp
@@ -51,6 +51,15 @@ void MeshShaderRenderPlugin::initActionList() {
 	//	}
 #endif
 	bool ret = shadersDir.cd("shaders");
+
+#if !defined(Q_OS_MAC) && !defined(Q_OS_WIN)
+	if (! ret) {
+		shadersDir = QDir(qApp->applicationDirPath());
+		if (shadersDir.dirName() == "bin") {
+			ret = shadersDir.cdUp() && shadersDir.cd("share")&& shadersDir.cd("meshlab") && shadersDir.cd("shaders");
+		}
+	}
+#endif
 	if (!ret)
 	{
 		QMessageBox::information(0, "MeshLab",


### PR DESCRIPTION
This permits installation of MeshLab system-wide on Linux (resembles a more generalized version of patches in some distributions):

If it doesn't look like we're using "distrib" directory layout (the executable is in "bin"),

- plugins are also searched in `../lib/meshlab/plugins` relative to the executable dir
- shaders are also searched in `../share/meshlab/shaders` relative to the executable dir

This reflects the installation choices made for Debian.

Split into a separate PR for discussion if any.