### PR TITLE
Fix: Check rastermodel not null

### DIFF
--- a/src/meshlabplugins/filter_layer/filter_layer.cpp
+++ b/src/meshlabplugins/filter_layer/filter_layer.cpp
@@ -182,7 +182,19 @@ bool FilterLayerPlugin::applyFilter(QAction *filter, MeshDocument &md, RichParam
  {
 	case  FP_RENAME_MESH:     md.mm()->setLabel(par.getString("newName")); break;
 
-	case  FP_RENAME_RASTER:   if (md.rm()) {md.rm()->setLabel(par.getString("newName"))}; break;
+	case  FP_RENAME_RASTER:
+	{
+    if (md.rm()) 
+    {
+      md.rm()->setLabel(par.getString("newName"));
+    }
+    else
+    {
+      this->errorMessage = "Error: Call to Rename Current Raster with no valid raster.";
+      return false;
+    }
+    
+	} break;
 
 	case  FP_SELECTCURRENT:   md.setCurrent(par.getMesh("layer")); break;
 
@@ -613,7 +625,7 @@ bool FilterLayerPlugin::applyFilter(QAction *filter, MeshDocument &md, RichParam
 			sscanf(line, "%d %d", &num_cams, &num_points);
 			
 			///// Check if the number of active rasters and cameras is the same
-			int active = 0;
+			unsigned active = 0;
 			for (int i = 0; i < md.rasterList.size(); i++)
 			{
 				if (md.rasterList[i]->visible)
@@ -622,8 +634,7 @@ bool FilterLayerPlugin::applyFilter(QAction *filter, MeshDocument &md, RichParam
 
 			if (active != num_cams)
 			{
-				this->errorMessage = "Error!";
-				errorMessage = "Wait! The number of active rasters and the number of cams in the Bundler file is not the same!";
+				this->errorMessage = "Wait! The number of active rasters and the number of cams in the Bundler file is not the same!";
 				return false;
 			}
 

--- a/src/meshlabplugins/filter_layer/filter_layer.cpp
+++ b/src/meshlabplugins/filter_layer/filter_layer.cpp
@@ -76,8 +76,8 @@ QString FilterLayerPlugin::filterName(FilterIDType filterId) const
     case FP_RENAME_RASTER :  return QString("Rename Current Raster");
     case FP_SELECTCURRENT :  return QString("Change the current layer");
     case FP_MESH_VISIBILITY :  return QString("Change Visibility of layer(s)");
-	case FP_EXPORT_CAMERAS:  return QString("Export active rasters cameras to file");
-	case FP_IMPORT_CAMERAS:  return QString("Import cameras for active rasters from file");
+    case FP_EXPORT_CAMERAS:  return QString("Export active rasters cameras to file");
+    case FP_IMPORT_CAMERAS:  return QString("Import cameras for active rasters from file");
     default : assert(0);
     }
 	return NULL;
@@ -100,8 +100,8 @@ QString FilterLayerPlugin::filterInfo(FilterIDType filterId) const
     case FP_RENAME_RASTER :  return QString("Explicitly change the label shown for a given raster");
     case FP_SELECTCURRENT :  return QString("Change the current layer to a chosen one");
     case FP_MESH_VISIBILITY :  return QString("Make layer(s) visible/invisible. Useful for scripting.");
-	case FP_EXPORT_CAMERAS:  return QString("Export active cameras to file, in the .out or Agisoft .xml formats");
-	case FP_IMPORT_CAMERAS:  return QString("Import cameras for active rasters from .out or Agisoft .xml formats");
+    case FP_EXPORT_CAMERAS:  return QString("Export active cameras to file, in the .out or Agisoft .xml formats");
+    case FP_IMPORT_CAMERAS:  return QString("Import cameras for active rasters from .out or Agisoft .xml formats");
     default : assert(0);
     }
 	return NULL;
@@ -144,7 +144,7 @@ void FilterLayerPlugin::initParameterSet(QAction *action, MeshDocument &md, Rich
         break;
     case FP_RENAME_RASTER :
         parlst.addParam(new RichString ("newName",
-            rm->label(),
+            rm?rm->label():"",
             "New Label",
             "New Label for the raster"));
         break;
@@ -182,7 +182,7 @@ bool FilterLayerPlugin::applyFilter(QAction *filter, MeshDocument &md, RichParam
  {
 	case  FP_RENAME_MESH:     md.mm()->setLabel(par.getString("newName")); break;
 
-	case  FP_RENAME_RASTER:   md.rm()->setLabel(par.getString("newName")); break;
+	case  FP_RENAME_RASTER:   if (md.rm()) {md.rm()->setLabel(par.getString("newName"))}; break;
 
 	case  FP_SELECTCURRENT:   md.setCurrent(par.getMesh("layer")); break;
 


### PR DESCRIPTION
This is a fix for a bug produced when executing `meshlabserver -d help.txt`.

The program try to access rasterModel::label() using a null pointer, so meshlabserver crash immediately.