### PR TITLE
Fix 434 Trivial validation of file paths

### DIFF
--- a/src/meshlabserver/mainserver.cpp
+++ b/src/meshlabserver/mainserver.cpp
@@ -31,7 +31,6 @@
 #include <common/mlexception.h>
 #include <common/filterparameter.h>
 #include <wrap/qt/qt_thread_safe_memory_info.h>
-#include "../meshlab/mainwindow.h"
 #include <clocale>
 
 #include <QGLFormat>
@@ -159,7 +158,7 @@ public:
 
         RichParameterSet prePar;
         pCurrentIOPlugin->initPreOpenParameter(extension, fileName,prePar);
-		prePar.join(defaultGlobal);
+        prePar.join(defaultGlobal);
 
         if (!pCurrentIOPlugin->open(extension, fileName, mm ,mask,prePar))
         {
@@ -245,9 +244,9 @@ public:
 
     bool openProject(MeshDocument& md,const QString& filename)
     {
-      QDir curDir = QDir::current();
+        QDir curDir = QDir::current();
         QFileInfo fi(filename);
-		std::map<int, MLRenderingData> tmp;
+        std::map<int, MLRenderingData> tmp;
         bool opened = MeshDocumentFromXML(md,fi.absoluteFilePath(), fi.suffix().toLower() == "mlb",tmp);
         if (!opened)
             return false;
@@ -581,7 +580,7 @@ public:
 private:
     PluginManager PM;
     RichParameterSet defaultGlobal;
-	MLSceneGLSharedDataContext* shared;
+    MLSceneGLSharedDataContext* shared;
 };
 
 namespace commandline
@@ -591,20 +590,20 @@ namespace commandline
     const char overwrite('x');
     const char inputmeshes('i');
     const char outputmesh('o');
-	const char layer('l');
-	const char lastlayer('x');
-	const char currentlayer('c');
+    const char layer('l');
+    const char lastlayer('x');
+    const char currentlayer('c');
     const char mask('m');
     const char vertex('v');
     const char face('f');
     const char wedge('w');
-	const char mesh('m');
+    const char mesh('m');
     const char color('c');
     const char flags('f');
     const char normal('n');
     const char quality('q');
     const char radius('r');
-	const char polygon('p');
+    const char polygon('p');
     const char texture('t');
     const char log('l');
     const char dump('d');
@@ -614,8 +613,8 @@ namespace commandline
 
     void usage()
     {
-		printf("MeshLabServer version: %s\n", qUtf8Printable(MeshLabApplication::appVer()));
-		QFile docum(":/meshlabserver.txt");
+        printf("MeshLabServer version: %s\n", qUtf8Printable(MeshLabApplication::appVer()));
+        QFile docum(":/meshlabserver.txt");
         if (!docum.open(QIODevice::ReadOnly))
         {
             printf("MeshLabServer was not able to locate meshlabserver.txt file. The program will be closed\n");
@@ -626,17 +625,10 @@ namespace commandline
         docum.close();
     }
 
-	QString filePath()
-	{
-		QString filecharcont("[a-z]|[A-Z]|\\\\|/|\\d|-|_|\\.|\\:");
-		QString filechars("(" + filecharcont + ")+");
-		QString filecharswithspace("(" + filecharcont + "|\\s)+");
-		return QString("(\"" + filecharswithspace + "\"|" + filechars + ")");
-	}
-
     QString optionValueExpression(const char cmdlineopt)
     {
-        return QString ("-" + QString(cmdlineopt) + "\\s+" + filePath());
+        //Validate an option followed by spaces and a filepath
+        return QString ("-" + QString(cmdlineopt) + "\\s+(.+)");
     }
 
     QString outputmeshExpression()
@@ -646,22 +638,21 @@ namespace commandline
 		QString savingmask("-" + QString(mask) + "\\s+" + optionslist);
 		QString layernumber("\\d+");
 		QString layertosave("-" + QString(layer) + "\\s+(" + layernumber + "|" + currentlayer + "|" + lastlayer + ")");
-        return optionValueExpression(outputmesh) + "(\\s+(" + savingmask + "|" + layertosave + "\\s+" + savingmask + "|" + layertosave + "))*";
+		return optionValueExpression(outputmesh) + "(\\s+(" + savingmask + "|" + layertosave + "\\s+" + savingmask + "|" + layertosave + "))*";
     }
 
     bool validateCommandLine(const QString& str)
     {
         QString logstring("(" + optionValueExpression(log) + "\\s+" +  optionValueExpression(dump) + "|" + optionValueExpression(dump) + "\\s+" +  optionValueExpression(log) + "|" +  optionValueExpression(dump) + "|" + optionValueExpression(log) + ")");
-        //QString remainstring("(" + optionValueExpression(inproject) + "|" + optionValueExpression(inputmeshes,true) + ")" + "(\\s+" + optionValueExpression(inproject) + "|\\s+" + optionValueExpression(inputmeshes,true) + ")*(\\s+" + optionValueExpression(outproject) + "|\\s+" + optionValueExpression(script) + "|\\s+" + outputmeshExpression() + ")*");
         QString arg("(" + optionValueExpression(inproject) + "|" + optionValueExpression(inputmeshes) + "|" + optionValueExpression(outproject) + "(\\s+-" + overwrite + ")?" + "|" + optionValueExpression(script) + "|" + outputmeshExpression() + ")");
         QString args("(" + arg + ")(\\s+" + arg + ")*");
         QString completecommandline("(" + logstring + "|" + logstring + "\\s+" + args + "|" + args + ")");
         QRegExp completecommandlineexp(completecommandline);
-		//completecommandlineexp.setMinimal(true);
+        //completecommandlineexp.setMinimal(true);
 
-		bool valid = completecommandlineexp.isValid();
-		if (!valid)
-			return false;
+        bool valid = completecommandlineexp.isValid();
+        if (!valid)
+            return false;
         completecommandlineexp.indexIn(str);
         QString rr = completecommandlineexp.cap();
         return (completecommandlineexp.matchedLength() == str.size());
@@ -676,15 +667,19 @@ struct OutFileMesh
     int mask;
     bool writebinary;
 	/*WARNING!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
-	/*we need these two constant values because when we parse the command line we don't know yet how many layers will have the current document and which will be the current one. Opening a project and/or importing a file happens after the parsing of the commandline is completed*/
+	/* We need these two constant values because when we parse the command line we don't know 
+   * yet how many layers will have the current document and which will be the current one. 
+   * Opening a project and/or importing a file happens after the parsing of the commandline 
+   * is completed */
 	static const int lastlayerconst = -2;
 	static const int currentlayerconst = -1;
-	/**********************************************************************************************************************************************************************************************************************/
+	/******************************************************************************************/
 
-	//possible values can be:
+	// Possible values can be:
 	//	- lastlayerconst #the last layer of a document, DEFAULT value
 	//	- currentlayerconst #the current layer of a document, sometimes it's different from the last layer of a document
-	//	- a number between [0,inf) #identifying the correspondent layer position  WARNING!!!!! Please note that the layer position is DIFFERENT from the layer id
+	//	- a number between [0,inf) #identifying the correspondent layer position  
+  // WARNING!!!!! Please note that the layer position is DIFFERENT from the layer id
 	int layerposition;
 };
 
@@ -699,13 +694,13 @@ int main(int argc, char *argv[])
     FILE* logfp = stdout;
     FILE* dumpfp = NULL;
     MeshLabApplication app(argc, argv);
-	QStringList st = app.arguments();
-	std::setlocale(LC_ALL, "C");
-	QLocale::setDefault(QLocale::C);
+    QStringList st = app.arguments();
+    std::setlocale(LC_ALL, "C");
+    QLocale::setDefault(QLocale::C);
     if(argc == 1)
     {
         commandline::usage();
-		//system("pause");
+        //system("pause");
         exit(-1);
     }
     QStringList scriptfiles;
@@ -713,25 +708,25 @@ int main(int argc, char *argv[])
     QList<OutProject> outprojectfiles;
 
     QString cmdline;
-	for (int ii = 1; ii < argc; ++ii)
-	{
-		QString argum(argv[ii]);
-		argum = argum.trimmed();
-		if (argum.contains(' '))
-			argum = "\"" + argum + "\"";
-		cmdline = cmdline + argum + " ";
-	}
+    for (int ii = 1; ii < argc; ++ii)
+    {
+        QString argum(argv[ii]);
+        argum = argum.trimmed();
+        if (argum.contains(' '))
+            argum = "\"" + argum + "\"";
+        cmdline = cmdline + argum + " ";
+    }
     if (!commandline::validateCommandLine(cmdline.trimmed()))
     {
         printf("CommandLine Syntax Error: please refer to the following documentation for a complete list of the MeshLabServer parameters.\n");
         commandline::usage();
-		//system("pause");
+        //system("pause");
         exit(-1);
     }
 
 	QSettings settings(MeshLabApplication::organization(),MeshLabApplication::appArchitecturalName(MeshLabApplication::HW_64BIT));
 
-	QVariant xmlgpupar = settings.value(MainWindowSetting::maximumDedicatedGPUMem());
+	QVariant xmlgpupar = settings.value("MeshLab::System::maxGPUMemDedicatedToGeometry");
 
 	QDomDocument doc;
 	doc.setContent(xmlgpupar.toString(), false);
@@ -1070,11 +1065,13 @@ int main(int argc, char *argv[])
 	}//for(int ii
 
 
-    if((logfp != NULL) && (logfp != stdout))
-        fclose(logfp);
+	if((logfp != NULL) && (logfp != stdout))
+	{
+		fclose(logfp);
+	}
 
 	shared.deAllocateGPUSharedData();
 	//system("pause");
-    return 0;
-}
+	return 0;
+}//int main()
 


### PR DESCRIPTION
This is a fix to #434 

Before this fix, meshlabserves crashes with input filenames like `input~1.ply`, `input+1.ply` 
Just don't try to validate file paths, because it is a hard task due to several OS supported. In case of non valid path, an error will be produced later when trying to open the file for reading or writing. (Line 631) 

Also: Remove dependence from "../meshlab/mainwindow.h" header, which was included just to read a const string in maximumDedicatedGPUMem(). (Line 729)

Also: Fix lots of unaligned lines due to mixing tab/spaces. (rest of changes, most only whitespace)
