### PR TITLE
Rename Windows.Copy_Shot menu and add menu tooltips

### DIFF
--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -392,15 +392,18 @@ connectRenderModeActionList(rendlist);*/
 	viewFromMeshAct = new QAction(tr("View from Mesh Camera"), this);
 	viewFromRasterAct = new QAction(tr("View from Raster Camera"), this);
 	viewFromRasterAct->setShortcut(Qt::CTRL + Qt::Key_J);
-	viewFromFileAct = new QAction(tr("View from file"), this);
+	viewFromFileAct = new QAction(tr("Read camera settings from file"), this);
+	viewFromFileAct->setToolTip(tr("Restore camera settings from a XML description stored in a file."));
 	connect(viewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));
 	connect(viewFromMeshAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentMeshShot()));
 	connect(viewFromRasterAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentRasterShot()));
 
-	copyShotToClipboardAct = new QAction(tr("Copy shot"), this);
+	copyShotToClipboardAct = new QAction(tr("Copy camera settings to clipboard"), this);
+	copyShotToClipboardAct->setToolTip(tr("Save current camera settings to clipboard as a XML document that you can share or restore anytime."));
 	connect(copyShotToClipboardAct, SIGNAL(triggered()), this, SLOT(copyViewToClipBoard()));
 
-	pasteShotFromClipboardAct = new QAction(tr("Paste shot"), this);
+	pasteShotFromClipboardAct = new QAction(tr("Paste clipboard to camera settings"), this);
+	pasteShotFromClipboardAct->setToolTip(tr("Restore camera settings from a XML description stored in the clipboard."));
 	connect(pasteShotFromClipboardAct, SIGNAL(triggered()), this, SLOT(pasteViewFromClipboard()));
 
 	//////////////Action Menu Filters /////////////////////////////////////////////////////////////////////
@@ -618,6 +621,7 @@ void MainWindow::createMenus()
 
 	//////////////////// Menu Windows /////////////////////////////////////////////////////////////////////////
 	windowsMenu = menuBar()->addMenu(tr("&Windows"));
+	windowsMenu->setToolTipsVisible(true);
     updateWindowMenu();
 	menuBar()->addSeparator();
 
@@ -938,9 +942,9 @@ void MainWindow::fillFilterMenu()
 				//    filterToolBar->addAction(filterAction);
 			}
 		}
-		catch (ParsingException e)
+		catch (ParsingException &e)
 		{
-			meshDoc()->Log.Logf(GLLogStream::SYSTEM, e.what());
+			meshDoc()->Log.Logf(GLLogStream::SYSTEM, e.what(), "");
 		}
 	}
 }


### PR DESCRIPTION
This is a feature requested by two users in #531 and https://stackoverflow.com/questions/59326287/meshlab-possible-to-export-import-the-current-camera-configuration

Basically it is unclear the purpose of the option "Windows->Copy shot" (which saves current camera settings to clipboard as a small piece of XML).

I have renamed both QActions and added tooltips to explain its purpose. Yo can preview the result of this PR in next screenshots.

![image](https://user-images.githubusercontent.com/6451497/70985857-229f6280-20bd-11ea-96b1-c74607805ab2.png)


![image](https://user-images.githubusercontent.com/6451497/70985881-2af79d80-20bd-11ea-9f23-ce6a042fc12a.png)

Also: Removed build warning on line 946.

Closes  #531 
