### PR TITLE
Exit after printing the help message

### DIFF
--- a/src/meshlab/main.cpp
+++ b/src/meshlab/main.cpp
@@ -59,12 +59,15 @@ int main(int argc, char *argv[])
         QString helpOpt1="-h";
         QString helpOpt2="--help";
         if( (helpOpt1==argv[1]) || (helpOpt2==argv[1]) )
+          {
             printf(
             "usage:\n"
             "meshlab <meshfile>\n"
             "Look at http://www.meshlab.net\n"
             "for a longer documentation\n"
             );
+            return 0;
+          }
 
         for (int i = 1; i < argc; ++i)
         {


### PR DESCRIPTION
If meshlab is invoked with the --help option, it prints the usage, and then it tries to open the "--help" file. The correct behavior is to exit after printing the usage. 