### PR TITLE
Bugfix when changing directory

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -2756,24 +2756,32 @@ bool MainWindow::loadMesh(const QString& fileName, MeshIOInterface *pCurrentIOPl
         return false;
     }
 
+    // the original directory path before we switch it
+    QString origDir = QDir::current().path();
+    
     // this change of dir is needed for subsequent textures/materials loading
     QDir::setCurrent(fi.absoluteDir().absolutePath());
 
+    // Adjust the file name after changing the directory
+    QString fileNameSansDir = fi.fileName();
+    
     // retrieving corresponding IO plugin
     if (pCurrentIOPlugin == 0)
     {
         QString errorMsgFormat = "Error encountered while opening file:\n\"%1\"\n\nError details: The \"%2\" file extension does not correspond to any supported format.";
         QMessageBox::critical(this, tr("Opening Error"), errorMsgFormat.arg(fileName, extension));
+        QDir::setCurrent(origDir); // undo the change of directory before leaving
         return false;
     }
     meshDoc()->setBusy(true);
     pCurrentIOPlugin->setLog(&meshDoc()->Log);
 
-    if (!pCurrentIOPlugin->open(extension, fileName, *mm ,mask,*prePar,QCallBack,this /*gla*/))
+    if (!pCurrentIOPlugin->open(extension, fileNameSansDir, *mm ,mask,*prePar,QCallBack,this /*gla*/))
     {
         QMessageBox::warning(this, tr("Opening Failure"), QString("While opening: '%1'\n\n").arg(fileName)+pCurrentIOPlugin->errorMsg()); // text+
         pCurrentIOPlugin->clearErrorString();
         meshDoc()->setBusy(false);
+        QDir::setCurrent(origDir); // undo the change of directory before leaving
         return false;
     }
 
@@ -2843,6 +2851,8 @@ bool MainWindow::loadMesh(const QString& fileName, MeshIOInterface *pCurrentIOPl
 
 
     meshDoc()->setBusy(false);
+
+    QDir::setCurrent(origDir); // undo the change of directory before leaving
 
     return true;
 }


### PR DESCRIPTION
Sometimes meshlab need to temporarily change the current directory, such as when reading textures or materials for a mesh. When doing that, it forgot to do two things tough:
 
 - Adjusting the path to the mesh now that the directory is changed
 - Undoing the change of directory when the loading was done

As result, it would get confused and it could not load either the desired file, or subsequent files that were in a different directory.

Here's a little fix for this. To reproduce the bug, and test the fix, one can do (on Linux or Mac) from the command line:

meshlab dir1/file1.ply file2.ply

