### PR TITLE
Turn off note sending email to developers

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -3626,7 +3626,9 @@ void MainWindow::showEvent(QShowEvent * event)
 		checkForUpdates(false);
 		settings.setValue(versioncheckeddatestring, todayStr);
 	}
-	sendUsAMail();
+
+	// Turn off the periodic pop-up asking to send email to developers
+	// sendUsAMail();
 }
 
 void MainWindow::meshAdded(int mid)


### PR DESCRIPTION
Dear Meshlab developers,

I really find Meshlab to be invaluable, both as a mesh viewer, and as a platform on which to quickly experiment with the many algorithms in the VCG library. I know that writing this tool was likely many thousands of hours of work, maybe even unpaid, and surely not well-acknowledged. Thank you so much. I hope you can continue with your enthusiasm in improving this free software. 

I will now bring up an issue that will likely contradict the existing tradition, but I think that it is important to address, now that Meshlab is basically the standard tool for mesh viewing. 

The pop-up asking users to send developers an email, which I see every couple of days, is a nuisance. I understand the logic behind it, and again, I admire your work. But please consider for a moment that your busy day is often interrupted by the Linux kernel, your favorite code editor, or the app you use to find a date :) persistently reminding you to thank its creator. The first time you likely will be glad to be informed of something you did not know, but after a few more attempts you won't appreciate it, as much as your life depends on that functionality. 

I will request Meshlab become a mature software, part of the vital infrastructure we use daily, and limit itself with a standard note in the "About" menu that mentions the developers, with additional information in the documentation, etc. True, we'll think less of its creators that way, but we, developers, are already used to be contacted only when our stuff is broken, and I don't think we need constant praises to do a good job. 