### PR TITLE
Load a camera view when a mesh is loaded

### DIFF
--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -2016,14 +2016,14 @@ bool GLArea::readViewFromFile()
 
 bool GLArea::saveViewToFile()
 {
-    QFileDialog* saveDiag = new QFileDialog(this,tr("Save View To File"), "./", tr("View file (*.xml)"));
+    QFileDialog saveDiag(this, tr("Save View To File"), "./", tr("View file (*.xml)"));
 
 #if defined(Q_OS_WIN)
-    saveDiag->setOption(QFileDialog::DontUseNativeDialog);
+    saveDiag.setOption(QFileDialog::DontUseNativeDialog);
 #endif
-    saveDiag->setAcceptMode(QFileDialog::AcceptSave);
-    saveDiag->exec();
-    QStringList files = saveDiag->selectedFiles();
+    saveDiag.setAcceptMode(QFileDialog::AcceptSave);
+    saveDiag.exec();
+    QStringList files = saveDiag.selectedFiles();
     if (files.size() != 1)
         return;
     QString fileName = files[0];
@@ -2033,7 +2033,7 @@ bool GLArea::saveViewToFile()
     if (fi.suffix().isEmpty())
     {
         QRegExp reg("\\.\\w+");
-        saveDiag->selectedNameFilter().indexOf(reg);
+        saveDiag.selectedNameFilter().indexOf(reg);
         QString ext = reg.cap();
         fileName.append(ext);
         fi.setFile(fileName);
@@ -2055,7 +2055,6 @@ bool GLArea::saveViewToFile()
 
     if(!ret)
       QMessageBox::critical(this, tr("Meshlab Saving Error"), QString("Unable to save view file %1\n").arg(fileName));
-    
     
     return true;
 }

--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -2025,11 +2025,11 @@ bool GLArea::saveViewToFile()
     saveDiag.exec();
     QStringList files = saveDiag.selectedFiles();
     if (files.size() != 1)
-        return;
+        return false;
     QString fileName = files[0];
     QFileInfo fi(fileName);
     if (fi.isDir())
-        return;
+        return false;
     if (fi.suffix().isEmpty())
     {
         QRegExp reg("\\.\\w+");
@@ -2042,7 +2042,7 @@ bool GLArea::saveViewToFile()
 
     bool ret = false;
 	qDebug("Saving a file %s\n", qUtf8Printable(fileName));
-    if (fileName.isEmpty()) return;
+    if (fileName.isEmpty()) return false;
     else
     {
         QFile qFile(fileName);
@@ -2053,7 +2053,7 @@ bool GLArea::saveViewToFile()
         }
     }
 
-    if(!ret)
+    if (!ret)
       QMessageBox::critical(this, tr("Meshlab Saving Error"), QString("Unable to save view file %1\n").arg(fileName));
     
     return true;

--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -1655,14 +1655,14 @@ void GLArea::updateFps(float deltaTime)
 
 void GLArea::resetTrackBall()
 {
-	makeCurrent();
+    makeCurrent();
     trackball.Reset();
     float newScale= 3.0f/this->md()->bbox().Diag();
     trackball.track.sca = newScale;
     trackball.track.tra.Import(-this->md()->bbox().Center());
     clipRatioNear = clipRatioNearDefault();
-	if (!isRaster())
-		fov=fovDefault();
+    if (!isRaster())
+        fov=fovDefault();
     update();
 }
 
@@ -1988,7 +1988,11 @@ void GLArea::initializeShot(Shotm &shot)
 bool GLArea::readViewFromFile()
 {
     QString filename = QFileDialog::getOpenFileName(this, tr("Load Project"), "./", tr("Xml Files (*.xml)"));
+    return GLArea::readViewFromFile(filename);
+}
 
+bool GLArea::readViewFromFile(QString const& filename)
+{
     QFile qf(filename);
     QFileInfo qfInfo(filename);
 
@@ -2008,7 +2012,7 @@ bool GLArea::readViewFromFile()
     //View State file
     else if(type == "ViewState") loadViewFromViewStateFile(doc);
 
-    qDebug("End file reading");
+    // qDebug("End file reading");
     qf.close();
 
     return true;

--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -1985,7 +1985,7 @@ void GLArea::initializeShot(Shotm &shot)
     shot.Extrinsics.SetIdentity();
 }
 
-bool GLArea::viewFromFile()
+bool GLArea::readViewFromFile()
 {
     QString filename = QFileDialog::getOpenFileName(this, tr("Load Project"), "./", tr("Xml Files (*.xml)"));
 
@@ -2011,6 +2011,52 @@ bool GLArea::viewFromFile()
     qDebug("End file reading");
     qf.close();
 
+    return true;
+}
+
+bool GLArea::saveViewToFile()
+{
+    QFileDialog* saveDiag = new QFileDialog(this,tr("Save View To File"), "./", tr("View file (*.xml)"));
+
+#if defined(Q_OS_WIN)
+    saveDiag->setOption(QFileDialog::DontUseNativeDialog);
+#endif
+    saveDiag->setAcceptMode(QFileDialog::AcceptSave);
+    saveDiag->exec();
+    QStringList files = saveDiag->selectedFiles();
+    if (files.size() != 1)
+        return;
+    QString fileName = files[0];
+    QFileInfo fi(fileName);
+    if (fi.isDir())
+        return;
+    if (fi.suffix().isEmpty())
+    {
+        QRegExp reg("\\.\\w+");
+        saveDiag->selectedNameFilter().indexOf(reg);
+        QString ext = reg.cap();
+        fileName.append(ext);
+        fi.setFile(fileName);
+    }
+    QDir::setCurrent(fi.absoluteDir().absolutePath());
+
+    bool ret = false;
+	qDebug("Saving a file %s\n", qUtf8Printable(fileName));
+    if (fileName.isEmpty()) return;
+    else
+    {
+        QFile qFile(fileName);
+        if (qFile.open(QIODevice::WriteOnly)) {
+          QTextStream out(&qFile); out << this->viewToText();
+          qFile.close();
+          ret = true;
+        }
+    }
+
+    if(!ret)
+      QMessageBox::critical(this, tr("Meshlab Saving Error"), QString("Unable to save view file %1\n").arg(fileName));
+    
+    
     return true;
 }
 

--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -523,16 +523,17 @@ private:
 public:
     QPair<Shotm, float > shotFromTrackball();
     void viewFromCurrentShot(QString kind);
-    bool viewFromFile();
+    bool saveViewToFile();
+    bool readViewFromFile();
     void createOrthoView(QString);
-	void toggleOrtho();
-	void trackballStep(QString);
+    void toggleOrtho();
+    void trackballStep(QString);
     void viewToClipboard();
     QString viewToText();
     void viewFromClipboard();
     void loadShot(const QPair<Shotm, float> &) ;
-	void loadShotFromTextAlignFile(const QDomDocument &doc);
-	void loadViewFromViewStateFile(const QDomDocument &doc);
+    void loadShotFromTextAlignFile(const QDomDocument &doc);
+    void loadViewFromViewStateFile(const QDomDocument &doc);
 
 private:
 

--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -415,8 +415,8 @@ protected:
     void hideEvent(QHideEvent * event);
 
 private:
-	void renderingFacilityString();
-	QString renderfacility;
+    void renderingFacilityString();
+    QString renderfacility;
     void setLightingColors(const MLPerViewGLOptions& opts);
 
     QMap<QString,QCursor> curMap;
@@ -525,6 +525,7 @@ public:
     void viewFromCurrentShot(QString kind);
     bool saveViewToFile();
     bool readViewFromFile();
+    bool readViewFromFile(QString const& filename);
     void createOrthoView(QString);
     void toggleOrtho();
     void trackballStep(QString);

--- a/src/meshlab/main.cpp
+++ b/src/meshlab/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
     app.installEventFilter(filterObj);
     app.processEvents();
 
+    // Can load multiple meshes and projects, and also a camera view
     if(argc>1)
     {
         QString helpOpt1="-h";
@@ -66,13 +67,23 @@ int main(int argc, char *argv[])
             "for a longer documentation\n"
             );
 
+        std::vector<QString> cameraViews;
         for (int i = 1; i < argc; ++i)
         {
             QString arg = QString::fromLocal8Bit(argv[i]);
             if(arg.endsWith("mlp",Qt::CaseInsensitive) || arg.endsWith("mlb",Qt::CaseInsensitive) || arg.endsWith("aln",Qt::CaseInsensitive) || arg.endsWith("out",Qt::CaseInsensitive) || arg.endsWith("nvm",Qt::CaseInsensitive))
                 window.openProject(arg);
+            else if(arg.endsWith("xml",Qt::CaseInsensitive))
+                cameraViews.push_back(arg); 
             else
                 window.importMeshWithLayerManagement(arg);
+        }
+        
+        // Load the view after everything else
+        if (!cameraViews.empty()) {
+          if (cameraViews.size() > 1) 
+            printf("Multiple views specified. Loading the last one.\n");
+          window.readViewFromFile(cameraViews.back());
         }
     }
     //else 	if(filterObj->noEvent) window.open();

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -217,9 +217,10 @@ private slots:
     void setUnsplit();
     void linkViewers();
     void viewFrom(QAction *qa);
-	void toggleOrtho();
-	void trackballStep(QAction *qa);
+    void toggleOrtho();
+    void trackballStep(QAction *qa);
     void readViewFromFile();
+    void saveViewToFile();
     void viewFromCurrentMeshShot();
     void viewFromCurrentRasterShot();
     void copyViewToClipBoard();
@@ -507,6 +508,7 @@ private:
     QAction *viewFromMeshAct;
     QAction *viewFromRasterAct;
     QAction *viewFromFileAct;
+    QAction *viewToFileAct;
 
 	QAction *toggleOrthoAct;
 

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -507,8 +507,8 @@ private:
 	QAction *viewBackYAct;
     QAction *viewFromMeshAct;
     QAction *viewFromRasterAct;
-    QAction *viewFromFileAct;
-    QAction *viewToFileAct;
+    QAction *readViewFromFileAct;
+    QAction *saveViewToFileAct;
 
 	QAction *toggleOrthoAct;
 

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -166,9 +166,10 @@ public:
     void getRenderingData(int mid,MLRenderingData& dt) const;
     void setRenderingData(int mid,const MLRenderingData& dt);
 
-	unsigned int viewsRequiringRenderingActions(int meshid,MLRenderingAction* act);
+    unsigned int viewsRequiringRenderingActions(int meshid,MLRenderingAction* act);
 
     void updateSharedContextDataAfterFilterExecution(int postcondmask,int fclasses,bool& newmeshcreated);
+    void readViewFromFile(QString const& filename);
 
 private slots:
 	void closeCurrentDocument();

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -392,10 +392,12 @@ connectRenderModeActionList(rendlist);*/
 	viewFromMeshAct = new QAction(tr("View from Mesh Camera"), this);
 	viewFromRasterAct = new QAction(tr("View from Raster Camera"), this);
 	viewFromRasterAct->setShortcut(Qt::CTRL + Qt::Key_J);
-	viewFromFileAct = new QAction(tr("View from file"), this);
-	connect(viewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));
+	viewFromFileAct = new QAction(tr("Read view from file"), this);
+	viewToFileAct = new QAction(tr("Save view to file"), this);
 	connect(viewFromMeshAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentMeshShot()));
 	connect(viewFromRasterAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentRasterShot()));
+	connect(viewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));
+	connect(viewToFileAct, SIGNAL(triggered()), this, SLOT(saveViewToFile()));
 
 	copyShotToClipboardAct = new QAction(tr("Copy shot"), this);
 	connect(copyShotToClipboardAct, SIGNAL(triggered()), this, SLOT(copyViewToClipBoard()));

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -392,12 +392,12 @@ connectRenderModeActionList(rendlist);*/
 	viewFromMeshAct = new QAction(tr("View from Mesh Camera"), this);
 	viewFromRasterAct = new QAction(tr("View from Raster Camera"), this);
 	viewFromRasterAct->setShortcut(Qt::CTRL + Qt::Key_J);
-	viewFromFileAct = new QAction(tr("Read view from file"), this);
-	viewToFileAct = new QAction(tr("Save view to file"), this);
+	readViewFromFileAct = new QAction(tr("Read view from file"), this);
+	saveViewToFileAct = new QAction(tr("Save view to file"), this);
 	connect(viewFromMeshAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentMeshShot()));
 	connect(viewFromRasterAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentRasterShot()));
-	connect(viewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));
-	connect(viewToFileAct, SIGNAL(triggered()), this, SLOT(saveViewToFile()));
+	connect(readViewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));
+	connect(saveViewToFileAct, SIGNAL(triggered()), this, SLOT(saveViewToFile()));
 
 	copyShotToClipboardAct = new QAction(tr("Copy shot"), this);
 	connect(copyShotToClipboardAct, SIGNAL(triggered()), this, SLOT(copyViewToClipBoard()));

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -211,8 +211,8 @@ void MainWindow::updateWindowMenu()
 			trackballStepMenu->addAction(ac);
 
         // View From File act
-        windowsMenu->addAction(viewFromFileAct);
-        windowsMenu->addAction(viewToFileAct);
+        windowsMenu->addAction(readViewFromFileAct);
+        windowsMenu->addAction(saveViewToFileAct);
         windowsMenu->addAction(viewFromMeshAct);
         windowsMenu->addAction(viewFromRasterAct);
 

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -409,10 +409,10 @@ void MainWindow::updateMenus()
     renderMenu->setEnabled(!renderMenu->actions().isEmpty());
     updateMenuItems(renderMenu,activeDoc);
     fullScreenAct->setEnabled(activeDoc);
-	showLayerDlgAct->setEnabled(activeDoc);
-	showTrackBallAct->setEnabled(activeDoc);
-	resetTrackBallAct->setEnabled(activeDoc);
-	showInfoPaneAct->setEnabled(activeDoc);
+    showLayerDlgAct->setEnabled(activeDoc);
+    showTrackBallAct->setEnabled(activeDoc);
+    resetTrackBallAct->setEnabled(activeDoc);
+    showInfoPaneAct->setEnabled(activeDoc);
     windowsMenu->setEnabled(activeDoc);
     preferencesMenu->setEnabled(activeDoc);
 
@@ -3267,6 +3267,11 @@ bool MainWindow::save(const bool saveAllPossibleAttributes)
 bool MainWindow::saveAs(QString fileName,const bool saveAllPossibleAttributes)
 {
     return exportMesh(fileName,meshDoc()->mm(),saveAllPossibleAttributes);
+}
+
+void MainWindow::readViewFromFile(QString const& filename){
+      if(GLA() != 0)
+          GLA()->readViewFromFile(filename);
 }
 
 bool MainWindow::saveSnapshot()

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -212,6 +212,7 @@ void MainWindow::updateWindowMenu()
 
         // View From File act
         windowsMenu->addAction(viewFromFileAct);
+        windowsMenu->addAction(viewToFileAct);
         windowsMenu->addAction(viewFromMeshAct);
         windowsMenu->addAction(viewFromRasterAct);
 
@@ -733,8 +734,13 @@ void MainWindow::trackballStep(QAction *qa)
 
 void MainWindow::readViewFromFile()
 {
-    if(GLA()) GLA()->viewFromFile();
+    if(GLA()) GLA()->readViewFromFile();
     updateMenus();
+}
+
+void MainWindow::saveViewToFile()
+{
+    if(GLA()) GLA()->saveViewToFile();
 }
 
 void MainWindow::viewFromCurrentMeshShot()


### PR DESCRIPTION
When doing repetitive work with meshes, I found it very helpful to load a preferred view of the mesh together with the mesh, such as:

meshlab mesh.ply cameraView.xml

rather than opening the mesh, and then zooming around, or loading the view from disk later. 

When multiple meshes and/or views are specified in various order, the meshes are loaded first, and only the last view is set. This  overwrites any calculated view for a particular mesh and the Qt screen drawing (paint event) is triggered only after the meshes are loaded and the view is set. 

This pull request is on top of pull request https://github.com/cnr-isti-vclab/meshlab/pull/541 which appears to be heading towards approval. The only new commit in this pull request is commit https://github.com/cnr-isti-vclab/meshlab/commit/1b8c60af0e3f7c6da3c9e15d8bbafd8875114a9b. 

I also cleaned up a few indentation issues along the way (I guess they come from mixing tabs with spaces).
