### PR TITLE
Fix menu wording and turn off verbose debugging info

### DIFF
--- a/src/common/filterparameter.cpp
+++ b/src/common/filterparameter.cpp
@@ -406,11 +406,11 @@ bool RichParameterAdapter::create( const QDomElement& np,RichParameter** par )
     QString desc=np.attribute("description");
     QString tooltip=np.attribute("tooltip");
 
-	QString isxml = np.attribute("isxmlparam");
-	if (isxml.isNull())
-		isxml = QString("0");
-
-    qDebug("    Reading Param with name %s : %s", qUtf8Printable(name), qUtf8Printable(type));
+    QString isxml = np.attribute("isxmlparam");
+    if (isxml.isNull())
+      isxml = QString("0");
+    
+    // qDebug("    Reading Param with name %s : %s", qUtf8Printable(name), qUtf8Printable(type));
 
     bool corrconv = false;
     if(type=="RichBool")
@@ -605,7 +605,7 @@ bool RichParameterAdapter::create(const QString& namepreamble, const MLXMLPlugin
 	QString desc = xmlparam[MLXMLElNames::guiLabel];
 	QString tooltip = xmlparam[MLXMLElNames::paramHelpTag];
 
-	qDebug("    Reading Param with name %s : %s", qUtf8Printable(name), qUtf8Printable(xmlparam[MLXMLElNames::paramDefExpr]));
+	// qDebug("    Reading Param with name %s : %s", qUtf8Printable(name), qUtf8Printable(xmlparam[MLXMLElNames::paramDefExpr]));
 
 	*par = new RichString(name, xmlparam[MLXMLElNames::paramDefExpr], desc, tooltip);
 	if (par != NULL)

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -392,10 +392,10 @@ connectRenderModeActionList(rendlist);*/
 	viewFromMeshAct = new QAction(tr("View from Mesh Camera"), this);
 	viewFromRasterAct = new QAction(tr("View from Raster Camera"), this);
 	viewFromRasterAct->setShortcut(Qt::CTRL + Qt::Key_J);
-  readViewFromFileAct = new QAction(tr("Read camera settings from file"), this);
-	readViewFromFileAct->setToolTip(tr("Restore camera settings from a XML description stored in a file."));
-	saveViewToFileAct = new QAction(tr("Save camera settings from file"), this);
-	saveViewToFileAct->setToolTip(tr("Save camera settings to a XML description stored in a file."));
+	readViewFromFileAct = new QAction(tr("Read camera settings from file"), this);
+	readViewFromFileAct->setToolTip(tr("Restore camera settings from an XML description stored in a file."));
+	saveViewToFileAct = new QAction(tr("Save camera settings to file"), this);
+	saveViewToFileAct->setToolTip(tr("Save camera settings to a file as an XML description."));
 	connect(viewFromMeshAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentMeshShot()));
 	connect(viewFromRasterAct, SIGNAL(triggered()), this, SLOT(viewFromCurrentRasterShot()));
 	connect(readViewFromFileAct, SIGNAL(triggered()), this, SLOT(readViewFromFile()));


### PR DESCRIPTION
My apologies for too many tiny pull requests. I'll try to take a break. :)

The few fixes I am putting here are for:

 - Inconsistent indentation.
 - Very verbose printing of all the settings at load time, they are hundreds of lines of text, those are available in the preferences settings in the GUI anyway.
 - Wording fix: "save from file" becomes "save to file".
 - Wording fix: "a xml" becomes "an xml" (in English, the "x" is pronounced "ex", so it sounds better to say "an xml" than "a xml").
 - Shortening a tooltip a little bit. 
