### PR TITLE
Allow the user to opt out from contacting the developers

### DIFF
--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -325,7 +325,7 @@ public slots:
 		}
 	}
 
-	void updatePerMeshDecorators(int mesh_id)
+	void updatePerMeshDecorators(int)
 	{
 		update();
 	}

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -1097,7 +1097,7 @@ void MainWindow::sendUsAMail()
 	bool dontRemindMeToSendEmailVal = false;
 	if (settings.contains(dontRemindMeToSendEmailVar))
 		dontRemindMeToSendEmailVal = settings.value(dontRemindMeToSendEmailVar).toBool();
-	if (dontRemindMeToSendEmailVal) 
+	if (dontRemindMeToSendEmailVal)
 		return;
 
 	int loadedMeshCounter = settings.value("loadedMeshCounter").toInt();
@@ -1111,9 +1111,11 @@ void MainWindow::sendUsAMail()
 		Ui::CongratsDialog temp;
 		temp.setupUi(congratsDialog);
 		temp.buttonBox->addButton("Send Mail", QDialogButtonBox::AcceptRole);
+
 		QCheckBox dontRemindMeCheckBox("Don't show this message again.");
 		dontRemindMeCheckBox.blockSignals(true);
 		temp.buttonBox->addButton(&dontRemindMeCheckBox, QDialogButtonBox::ActionRole);
+
 		congratsDialog->exec();
 		if (congratsDialog->result() == QDialog::Accepted)
 			QDesktopServices::openUrl(QUrl("mailto:p.cignoni@isti.cnr.it;g.ranzuglia@isti.cnr.it?subject=[MeshLab] Reporting Info on MeshLab Usage"));
@@ -1122,7 +1124,7 @@ void MainWindow::sendUsAMail()
 
 		// See if the user checked the box to not be reminded again
 		if (dontRemindMeCheckBox.checkState() == Qt::Checked)
-		settings.setValue(dontRemindMeToSendEmailVar, true);
+			settings.setValue(dontRemindMeToSendEmailVar, true);
 	}
 }
 

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -1091,6 +1091,15 @@ void MainWindow::saveRecentFileList(const QString &fileName)
 void MainWindow::sendUsAMail()
 {
 	QSettings settings;
+
+	// Check if the user specified not to be reminded to send email
+	const QString dontRemindMeToSendEmailVar("dontRemindMeToSendEmail");
+	bool dontRemindMeToSendEmailVal = false;
+	if (settings.contains(dontRemindMeToSendEmailVar))
+		dontRemindMeToSendEmailVal = settings.value(dontRemindMeToSendEmailVar).toBool();
+	if (dontRemindMeToSendEmailVal) 
+		return;
+
 	int loadedMeshCounter = settings.value("loadedMeshCounter").toInt();
 	//int connectionInterval = settings.value("connectionInterval", 20).toInt();
 	//int lastComunicatedValue = settings.value("lastComunicatedValue", 0).toInt();
@@ -1102,11 +1111,18 @@ void MainWindow::sendUsAMail()
 		Ui::CongratsDialog temp;
 		temp.setupUi(congratsDialog);
 		temp.buttonBox->addButton("Send Mail", QDialogButtonBox::AcceptRole);
+		QCheckBox dontRemindMeCheckBox("Don't show this message again.");
+		dontRemindMeCheckBox.blockSignals(true);
+		temp.buttonBox->addButton(&dontRemindMeCheckBox, QDialogButtonBox::ActionRole);
 		congratsDialog->exec();
 		if (congratsDialog->result() == QDialog::Accepted)
 			QDesktopServices::openUrl(QUrl("mailto:p.cignoni@isti.cnr.it;g.ranzuglia@isti.cnr.it?subject=[MeshLab] Reporting Info on MeshLab Usage"));
 		// This preference values store when you did the last request for a mail
 		settings.setValue("congratsMeshCounter", congratsMeshCounter * 2);
+
+		// See if the user checked the box to not be reminded again
+		if (dontRemindMeCheckBox.checkState() == Qt::Checked)
+		settings.setValue(dontRemindMeToSendEmailVar, true);
 	}
 }
 

--- a/src/meshlab/ml_default_decorators.cpp
+++ b/src/meshlab/ml_default_decorators.cpp
@@ -316,7 +316,7 @@ void MLDefaultMeshDecorators::drawQuotedLine(const vcg::Point3d &a,const vcg::Po
     glDisable(GL_LIGHT0);
     glDisable(GL_NORMALIZE);
     float labelMargin =tickScalarDistance /4.0;
-    float firstTick;
+    float firstTick = 0.0;
     // fmod returns the floating-point remainder of numerator/denominator (with the sign of the dividend)
     // fmod ( 104.5 , 10) returns 4.5     --> aVal - fmod(aval/tick) = 100
     // fmod ( -104.5 , 10) returns -4.5
@@ -333,7 +333,7 @@ void MLDefaultMeshDecorators::drawQuotedLine(const vcg::Point3d &a,const vcg::Po
 
 
     float tickDistTen=tickScalarDistance /10.0f;
-    float firstTickTen;
+    float firstTickTen = 0.0;
     if(aVal > 0) firstTickTen = aVal - fmod(aVal,tickDistTen) + tickDistTen;
     else firstTickTen = aVal - fmod(aVal,tickDistTen);
 


### PR DESCRIPTION
This follows the thought expressed by Paolo in https://github.com/cnr-isti-vclab/meshlab/issues/549 to allow the users to opt out of notifying developers. With this change, the pop-up asking folks to send an email sharing their amazing experience will still come up, but a check box, if checked, will save user's preference for the pop-up to not come again. 

I also fixed some compiler warnings about unitialized and unused variables. There are plenty more of such things left to sort out. 