### PR TITLE
Codespell and typo fixes.

### DIFF
--- a/src/meshlab/savemaskexporter.h
+++ b/src/meshlab/savemaskexporter.h
@@ -34,7 +34,7 @@
 //  a capability bit vector with all the things that it can save (the bits are the one indicated in the IOM_XXX bit mask) ; 
 //  a default bit vector that indicate what things are saved by defaults (eg. by default normals and flags are not saved in ply)
 //  a vector of optional parameters (like for example a bool for ascii/binary, a bool for choosing what  
-// This dialog allow to select what things actually save. 
+// This dialog allows one to select what things actually save. 
 // 
 // 
 // 

--- a/src/meshlabplugins/edit_align/edit_align.cpp
+++ b/src/meshlabplugins/edit_align/edit_align.cpp
@@ -47,7 +47,7 @@ EditAlignPlugin::EditAlignPlugin()
 
 const QString EditAlignPlugin::Info()
 {
-    return tr("Allow to align different layers together.");
+    return tr("Allows one to align different layers together.");
 }
 
 void EditAlignPlugin::suggestedRenderingData(MeshModel & /*m*/, MLRenderingData& dt)

--- a/src/meshlabplugins/edit_hole/fgtHole.h
+++ b/src/meshlabplugins/edit_hole/fgtHole.h
@@ -40,7 +40,7 @@
 
 /** An hole type, extends vcg::tri::Hole<MESH>::Info adding more information
  *  as filling, selection, filing autocompenetration and non manifoldness. 
- *  This class also allow to fill (and restore) an hole using different criteria.
+ *  This class also allows one to fill (and restore) an hole using different criteria.
  *
  *  FgtHole uses meshe's additional data to mark interesting face, so surfing 
  *  the hole faces is driven by face-face ajacency and mark meaning.

--- a/src/meshlabplugins/edit_measure/edit_measure.cpp
+++ b/src/meshlabplugins/edit_measure/edit_measure.cpp
@@ -40,7 +40,7 @@ EditMeasurePlugin::EditMeasurePlugin()
 
 const QString EditMeasurePlugin::Info()
 {
-    return tr("Allow to measure distances between points of a model");
+    return tr("Allows one to measure distances between points of a model");
 }
 
 void EditMeasurePlugin::mousePressEvent(QMouseEvent *, MeshModel &, GLArea * gla)

--- a/src/meshlabplugins/filter_camera/filter_camera.cpp
+++ b/src/meshlabplugins/filter_camera/filter_camera.cpp
@@ -68,8 +68,8 @@ QString FilterCameraPlugin::filterName(FilterIDType filterId) const
 QString FilterCameraPlugin::filterInfo(FilterIDType filterId) const
 {
     switch(filterId) {
-    case FP_SET_MESH_CAMERA :     return QString("This filter allow to set a shot for the current mesh");
-    case FP_SET_RASTER_CAMERA :   return QString("This filter allow to set a shot for the current mesh");
+    case FP_SET_MESH_CAMERA :     return QString("This filter allows one to set a shot for the current mesh");
+    case FP_SET_RASTER_CAMERA :   return QString("This filter allows one to set a shot for the current mesh");
     case FP_QUALITY_FROM_CAMERA : return QString("Compute vertex quality using the camera definition, according to viewing angle or distance");
     case FP_CAMERA_ROTATE :       return QString("Rotate the camera, or all the cameras of the project. The selected raster is the reference if viewpoint rotation is selected.");
     case FP_CAMERA_SCALE :        return QString("Scale the camera, or all the cameras of the project. The selected raster is the reference if viewpoint scaling is selected.");
@@ -161,11 +161,11 @@ void FilterCameraPlugin::initParameterSet(QAction *action, MeshDocument &/*m*/, 
 
         }
         break;  case FP_SET_RASTER_CAMERA :
-        parlst.addParam(new RichShotf ("Shot", defShot, "New shot", "This filter allow to set a shot for the current raster."));
+        parlst.addParam(new RichShotf ("Shot", defShot, "New shot", "This filter allows one to set a shot for the current raster."));
         break;
 
         case FP_SET_MESH_CAMERA :
-            parlst.addParam(new RichShotf ("Shot", defShot, "New shot", "This filter allow to set a shot for the current mesh."));
+            parlst.addParam(new RichShotf ("Shot", defShot, "New shot", "This filter allows one to set a shot for the current mesh."));
             break;
         case FP_QUALITY_FROM_CAMERA :
             parlst.addParam(new RichBool ("Depth", true, "Depth", "Use depth as a factor."));

--- a/src/meshlabplugins/filter_isoparametrization/dual_coord_optimization.h
+++ b/src/meshlabplugins/filter_isoparametrization/dual_coord_optimization.h
@@ -40,7 +40,7 @@ public:
     std::vector<MeshType*> HRES_meshes;
     std::vector<std::vector<VertexType*> > Ord_HVert;
 
-    ///hight resolution mesh and domain mesh
+    ///high resolution mesh and domain mesh
     MeshType *domain;
     MeshType *h_res_mesh;
 

--- a/src/meshlabplugins/filter_isoparametrization/filter_isoparametrization.cpp
+++ b/src/meshlabplugins/filter_isoparametrization/filter_isoparametrization.cpp
@@ -255,7 +255,7 @@ bool FilterIsoParametrization::applyFilter(QAction *filter, MeshDocument& md, Ri
         }
       }
       
-      // At this point we are sure that everithing went ok so we can allocate surely the abstract
+      // At this point we are sure that everything went ok so we can allocate surely the abstract
       AbstractMesh *abs_mesh = new AbstractMesh();
       ParamMesh *para_mesh = new ParamMesh();
       Parametrizator.ExportMeshes(*para_mesh,*abs_mesh);
@@ -275,7 +275,7 @@ bool FilterIsoParametrization::applyFilter(QAction *filter, MeshDocument& md, Ri
       bool Done=isoPHandle().LoadBaseDomain<CMeshO>(qUtf8Printable(AbsLoadName),mesh,para_mesh,abs_mesh,true);
       if (!Done)
       {
-        this->errorMessage="Abstract domain doesnt fit well with the parametrized mesh";
+        this->errorMessage="Abstract domain doesn't fit well with the parametrized mesh";
         delete para_mesh;
         delete abs_mesh;
         return false;
@@ -380,7 +380,7 @@ bool FilterIsoParametrization::applyFilter(QAction *filter, MeshDocument& md, Ri
 //    bool Done=isoPHandle().LoadBaseDomain<CMeshO>(path,mesh,para_mesh,abs_mesh,true);
 //    if (!Done)
 //    {
-//      this->errorMessage="Abstract domain doesnt fit well with the parametrized mesh";
+//      this->errorMessage="Abstract domain doesn't fit well with the parametrized mesh";
 //      delete para_mesh;
 //      delete abs_mesh;
 //      return false;

--- a/src/meshlabplugins/filter_isoparametrization/local_optimization.h
+++ b/src/meshlabplugins/filter_isoparametrization/local_optimization.h
@@ -73,7 +73,7 @@ typename MeshType::ScalarType StarDistorsion(typename MeshType::VertexType *v)
 	CreateMeshVertexStar(starCenter,ordered_faces,star_domain);
 	ParametrizeStarEquilateral<MeshType>(star_domain);
 
-	///get all the vertices in H definition that shuld be optimized
+	///get all the vertices in H definition that should be optimized
 	///and initialize vertices with u,v coordinates
 	for (unsigned int index=0;index<ordered_faces.size();index++)
 	{
@@ -132,7 +132,7 @@ void OptimizeStar(typename MeshType::VertexType *v,MeshType &domain,int accuracy
 	ParametrizeStarEquilateral<MeshType>(star_domain);
 	assert(testParamCoords(star_domain));
 
-	///get all the vertices in H definition that shuld be optimized
+	///get all the vertices in H definition that should be optimized
 	///and initialize vertices with u,v coordinates
 	for (unsigned int index=0;index<ordered_faces.size();index++)
 	{

--- a/src/meshlabplugins/filter_isoparametrization/param_collapse.h
+++ b/src/meshlabplugins/filter_isoparametrization/param_collapse.h
@@ -117,7 +117,7 @@ public:
         }
     }
 
-    ///then return pointer to hight level faces
+    ///then return pointer to high level faces
     getSharedFace<BaseMesh>(HiVertex,HiFace);
   }
 
@@ -364,7 +364,7 @@ public:
                 f0->FFi(indexopp0)=-1;
                 printf("border");
             }
-            else///otherwise attache two other faces
+            else///otherwise attach two other faces
             {
                 ///the reassing adiacency
                 f0->FFp(indexopp0)=f1;
@@ -444,7 +444,7 @@ void AphaBetaToUV(VertexPair &pos,
         FaceType *test_face=orderedFaces[index];
         FaceType *parametric_face=&param.face[index];
 
-        ///fro each vertex belonging to such face
+        ///for each vertex belonging to such face
         for (unsigned int i=0;i<test_face->vertices_bary.size();i++)
         {
             ///get brother vertex

--- a/src/meshlabplugins/filter_isoparametrization/parametrizator.h
+++ b/src/meshlabplugins/filter_isoparametrization/parametrizator.h
@@ -154,7 +154,7 @@ private:
             father->vertices_bary.push_back(std::pair<BaseVertex*,vcg::Point3f>(&final_mesh.vert[i],bary));
         }
 
-        ///testing everithing is ok
+        ///testing everything is ok
         for (unsigned int i=0;i<final_mesh.vert.size();i++)
         {
             final_mesh.vert[i].RPos=final_mesh.vert[i].P();

--- a/src/meshlabplugins/filter_isoparametrization/tangent_space.h
+++ b/src/meshlabplugins/filter_isoparametrization/tangent_space.h
@@ -48,7 +48,7 @@ public:
 	
 	///given an initial position in parametric space (I0,bary0)
 	///and a 2D vector (vect) expressed in parametric space modify the final 
-	///position (I1,bary1) abd return true if everithing was ok, false otherwise
+	///position (I1,bary1) and return true if everything was ok, false otherwise
 	bool Sum(const int &I0,const vcg::Point2<ScalarType> &bary0,
 			 const vcg::Point2<ScalarType> &vect,
 			 int &I1,vcg::Point2<ScalarType> &bary1,int &domain) const
@@ -121,7 +121,7 @@ public:
 	}
 	
 	///given two positions in parametric space (I0,bary0) and (I1,bary1)
-	///modify the 2D vector (vect) and return true if everithing was ok, false otherwise
+	///modify the 2D vector (vect) and return true if everything was ok, false otherwise
 	bool Sub(const int &I0,const vcg::Point2<ScalarType> &bary0,
 			 const int &I1,const vcg::Point2<ScalarType> &bary1,
 			 vcg::Point2<ScalarType> &vect,int &num) const

--- a/src/meshlabplugins/filter_isoparametrization/texcoord_optimization.h
+++ b/src/meshlabplugins/filter_isoparametrization/texcoord_optimization.h
@@ -629,7 +629,7 @@ public:
 };
 
 
-#if 0  // Temporarly commented out. It still have to be thoroughly tested...
+#if 0  // Temporarily commented out. It still have to be thoroughly tested...
 
 template<class MESH_TYPE> 
 class WachspressTexCoordOptimization:public TexCoordOptimization<MESH_TYPE>{

--- a/src/meshlabplugins/filter_meshing/meshfilter.cpp
+++ b/src/meshlabplugins/filter_meshing/meshfilter.cpp
@@ -415,7 +415,7 @@ void ExtraMeshFilterPlugin::initParameterSet(QAction * action, MeshModel & m, Ri
 		case FP_LOOP_SS:
 		case FP_REFINE_LS3_LOOP:
 			loopWeightLst << "Loop" << "Enhance regularity" << "Enhance continuity";
-		parlst.addParam(new RichEnum("LoopWeight", 0, loopWeightLst, "Weighting scheme", "Change the weights used. Allow to optimize some behaviors in despite of others."));
+		parlst.addParam(new RichEnum("LoopWeight", 0, loopWeightLst, "Weighting scheme", "Change the weights used. Allows one to optimize some behaviors over others."));
 		case FP_BUTTERFLY_SS:
 		case FP_MIDPOINT:
 			parlst.addParam(new RichInt("Iterations", 3, "Iterations", "Number of time the model is subdivided."));

--- a/src/meshlabplugins/filter_meshing/quadric_simp.cpp
+++ b/src/meshlabplugins/filter_meshing/quadric_simp.cpp
@@ -60,7 +60,7 @@ void QuadricSimplification(CMeshO &m,int  TargetFaceNum, bool Selected, tri::Tri
   if(Selected)
     TargetFaceNum= m.fn - (m.sfn-TargetFaceNum);
   DeciSession.SetTargetSimplices(TargetFaceNum);
-  DeciSession.SetTimeBudget(0.1f); // this allow to update the progress bar 10 time for sec...
+  DeciSession.SetTimeBudget(0.1f); // this allows updating the progress bar 10 time for sec...
   //  if(TargetError< numeric_limits<double>::max() ) DeciSession.SetTargetMetric(TargetError);
   //int startFn=m.fn;
   int faceToDel=m.fn-TargetFaceNum;

--- a/src/meshlabplugins/io_expe/import_expe.h
+++ b/src/meshlabplugins/io_expe/import_expe.h
@@ -248,7 +248,7 @@ class ImporterExpePTS
 				}
 				else
 				{
-					std::cerr << "Unknow command " << command.data() << " (skip)" << "\n";
+					std::cerr << "Unknown command " << command.data() << " (skip)" << "\n";
 				}
 				stream >> command;
 			}

--- a/src/plugins_experimental/edit_ocme/src/ocme/multiple_std_iterator.h
+++ b/src/plugins_experimental/edit_ocme/src/ocme/multiple_std_iterator.h
@@ -1,7 +1,7 @@
 
 
 /*
-stupid class to allow to run over a list of containers with the same type in a single "for" cycle
+stupid class to allow running over a list of containers with the same type in a single "for" cycle
 
 example:
 

--- a/src/plugins_experimental/edit_ocme/src/ocme/ocme_definition.h
+++ b/src/plugins_experimental/edit_ocme/src/ocme/ocme_definition.h
@@ -367,7 +367,7 @@ struct OCME{
 	// selection frustum in view space
 	vcg::Point4f sel_corners[8];
 
-	// returns the cells selected by the user and lock them (do not allow to be drop)
+	// returns the cells selected by the user and lock them (do not allow them to be dropped)
 	void Select(std::vector<Cell*> & selected);
 	// deselect previously locked cells
 	void DeSelect(std::vector<Cell*> & selected);


### PR DESCRIPTION
Partially directed by the Debian "lintian" tool. (Apparently it has the phrase "allow to" in its blacklist, since it's not grammatically correct.)