### PR TITLE
Install libmeshlab-common to meshlab lib subdir.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -64,5 +64,5 @@ target_link_libraries(
 set_property(TARGET common PROPERTY FOLDER Core)
 
 if(NOT WIN32)
-    install(TARGETS common DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(TARGETS common DESTINATION ${MESHLAB_LIB_INSTALL_DIR})
 endif()

--- a/src/templates/common.cmake
+++ b/src/templates/common.cmake
@@ -33,7 +33,7 @@ target_link_libraries({{name}}
 {% block install %}
 if(NOT WIN32)
     install(TARGETS {{name}}
-        DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        DESTINATION ${MESHLAB_LIB_INSTALL_DIR})
 endif()
 
 {% endblock %}


### PR DESCRIPTION
It has no soname, so shouldn't be in the search path.

Came up during Debian packaging.