### PR TITLE
Fix usage of system vs bundled qhull with CMake

### DIFF
--- a/.github/workflows/CompileWindows.yml
+++ b/.github/workflows/CompileWindows.yml
@@ -83,7 +83,7 @@ jobs:
         #mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
     - name: Configure
       run: |
-        cmake -S ./src -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+        cmake -S ./src -B ./build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON 
         # -DBUILD_MINI=ON
     - name: Build MeshLab
       run: |

--- a/src/external.cmake
+++ b/src/external.cmake
@@ -354,5 +354,6 @@ elseif(ALLOW_BUNDLED_QHULL AND EXISTS "${QHULL_DIR}/src/qhull.h")
         "${QHULL_DIR}/src/geom.h"
         "${QHULL_DIR}/src/user.c"
         "${QHULL_DIR}/src/user.h")
+    target_include_directories(external-qhull INTERFACE "${QHULL_DIR}/src")
     set_property(TARGET external-qhull PROPERTY FOLDER External)
 endif()

--- a/src/meshlabplugins/filter_qhull/qhull_tools.h
+++ b/src/meshlabplugins/filter_qhull/qhull_tools.h
@@ -55,14 +55,17 @@ extern "C"
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include "../../external/qhull-2003.1/src/qhull.h"
-#include "../../external/qhull-2003.1/src/mem.h"
-#include "../../external/qhull-2003.1/src/qset.h"
-#include "../../external/qhull-2003.1/src/geom.h"
-#include "../../external/qhull-2003.1/src/merge.h"
-#include "../../external/qhull-2003.1/src/poly.h"
-#include "../../external/qhull-2003.1/src/io.h"
-#include "../../external/qhull-2003.1/src/stat.h"
+
+// qhull includes - qhull/ omitted to support both system and bundled libs.
+#include "qhull.h"
+#include "mem.h"
+#include "qset.h"
+#include "geom.h"
+#include "merge.h"
+#include "poly.h"
+#include "io.h"
+#include "stat.h"
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
I had already done most of the work in CMake, but had apparently missed editing this header.