### PR TITLE
Pr609 rebased on #616 and with incorrect patch dropped

### DIFF
--- a/.github/workflows/CompileUbuntu.yml
+++ b/.github/workflows/CompileUbuntu.yml
@@ -81,3 +81,6 @@ jobs:
         cmake src/ -G Ninja
     - name: Build MeshLab
       run: ninja -C .
+    - name: Install Meshlab
+      run: sudo ninja -C . install
+

--- a/install/linux/resources/meshlab.desktop
+++ b/install/linux/resources/meshlab.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Name=MeshLab
+Name[en_GB]=MeshLab
+GenericName=Mesh processing
+GenericName[en_GB]=Mesh processing
+Comment=View and process meshes
+Type=Application
+Exec=meshlab %F
+Icon=/usr/share/pixmaps/meshlab.png
+Terminal=false
+MimeType=model/mesh;application/x-3ds;image/x-3ds;model/x-ply;application/sla;model/x-quad-object;model/x-geomview-off;application/x-cyclone-ptx;application/x-vmi;application/x-bre;model/vnd.collada+xml;model/openctm;application/x-expe-binary;application/x-expe-ascii;application/x-xyz;application/x-gts;chemical/x-pdb;application/x-tri;application/x-asc;model/x3d+xml;model/x3d+vrml;model/vrml;model/u3d;model/idtf;
+Categories=Graphics;3DGraphics;Viewer;Qt;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -354,8 +354,8 @@ if(INSTALL_SAMPLE_RANGEMAPS)
 endif()
 
 if(NOT WIN32 AND NOT APPLE)
-    install(FILES ../install/linux/resources/meshlab.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-    install(FILES ../install/meshlab.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/pixmaps)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../install/linux/resources/meshlab.desktop" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../install/meshlab.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/pixmaps)
 endif()
 
 if(Qt5_windeployqt_EXECUTABLE AND BUILD_WITH_WINDEPLOYQT_POST_BUILD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -355,7 +355,7 @@ endif()
 
 if(NOT WIN32 AND NOT APPLE)
     install(FILES ../install/linux/resources/meshlab.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-    install(FILES ../install/meshlab.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor)
+    install(FILES ../install/meshlab.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/pixmaps)
 endif()
 
 if(Qt5_windeployqt_EXECUTABLE AND BUILD_WITH_WINDEPLOYQT_POST_BUILD)


### PR DESCRIPTION
This is just the guts of #609, rebased on top of #616, and with one patch (changing the desktop file name - good idea, but the files that were in there were for appimages) dropped.