### PR TITLE
Fix compile arg for isoparametrization plugin

### DIFF
--- a/src/meshlabplugins/filter_isoparametrization/filter_isoparametrization.pro
+++ b/src/meshlabplugins/filter_isoparametrization/filter_isoparametrization.pro
@@ -35,7 +35,7 @@ linux:QMAKE_CXXFLAGS += -fopenmp -D_USE_OMP
 win32-msvc:LIBS	+= $$MESHLAB_DISTRIB_DIRECTORY/lib/win32-msvc/levmar.lib
 win32-g++:LIBS += -L$$MESHLAB_DISTRIB_DIRECTORY/lib/win32-gcc -llevmar
 macx:LIBS += $$MESHLAB_DISTRIB_DIRECTORY/lib/macx64/liblevmar.a
-linux:LIBS += -llevmar
+linux:LIBS += -fopenmp -llevmar
 
 # Please never ever uncomment this...
 #QMAKE_CXXFLAGS += -fpermissive


### PR DESCRIPTION
Hi, 

I experience an error when running iso parametrization filter
```
./meshlab: symbol lookup error: ... undefined symbol: GOMP_parallel
```
I found that adding the flag helped. 