### PR TITLE
Avoid unnecessarily turning off the layer dialog

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -1586,7 +1586,7 @@ void MainWindow::saveProject()
 bool MainWindow::openProject(QString fileName)
 {
     bool visiblelayer = layerDialog->isVisible();
-    showLayerDlg(false);
+    //showLayerDlg(false);
 	globrendtoolbar->setEnabled(false);
     if (fileName.isEmpty())
         fileName = QFileDialog::getOpenFileName(this,tr("Open Project File"), lastUsedDirectory.path(), tr("All Project Files (*.mlp *.mlb *.aln *.out *.nvm);;MeshLab Project (*.mlp);;MeshLab Binary Project (*.mlb);;Align Project (*.aln);;Bundler Output (*.out);;VisualSFM Output (*.nvm)"));
@@ -2244,7 +2244,7 @@ bool MainWindow::importMeshWithLayerManagement(QString fileName)
     if (layerDialog != NULL)
     {
         layervisible = layerDialog->isVisible();
-        showLayerDlg(false);
+        //showLayerDlg(false);
     }
 	globrendtoolbar->setEnabled(false);
     bool res = importMesh(fileName,false);


### PR DESCRIPTION
This is discussed in more detail in https://github.com/cnr-isti-vclab/meshlab/issues/706

There appears to be no good reason as to why the layer dialog on the right must disappear temporarily while a new mesh or new project is added, only to come back right after. It redraws the window unnecessarily which is not helping with the user experience. It gets worse when several meshes are open at the same time, as then it makes the layer dialog to flicker on and off several times.

My best guess is that this is a leftover from when the layer code was not robust enough. I now tested it  without hiding it and no harm is done when a new mesh is added, the layer dialog refreshes itself nicely. 