### PR TITLE
Fix build against gcc:10.1.0

### DIFF
--- a/src/external/structuresynth-1.5/ssynth/SyntopiaCore/GLEngine/Raytracer/AtomicCounter.h
+++ b/src/external/structuresynth-1.5/ssynth/SyntopiaCore/GLEngine/Raytracer/AtomicCounter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <climits>
 #include <QMutex>
 #include <QWaitCondition>
 


### PR DESCRIPTION
GCC:10 complains about missing `climits` header in `ssynt` 
`{os:Linux,dist:Arch,gcc:10.1.0,qt5:5.15.0}`
```cpp
In file included from /build/meshlab/src/meshlab/src/external/structuresynth-1.5/ssynth/SyntopiaCore/GLEngine/Raytracer/AtomicCounter.cpp:1:
/build/meshlab/src/meshlab/src/external/structuresynth-1.5/ssynth/SyntopiaCore/GLEngine/Raytracer/AtomicCounter.h:28:35: error: ‘ULONG_MAX’ was not declared in this scope
   28 |    bool wait(unsigned long time = ULONG_MAX) { wcm.lock(); bool w = wc.wait(&wcm,time); wcm.unlock(); return w; }
      |                                   ^~~~~~~~~
/build/meshlab/src/meshlab/src/external/structuresynth-1.5/ssynth/SyntopiaCore/GLEngine/Raytracer/AtomicCounter.h:5:1: note: ‘ULONG_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
    4 | #include <QWaitCondition>
  +++ |+#include <climits>
    5 |
```