### PR TITLE
Install the icon to /usr/share/pixmaps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -343,7 +343,7 @@ endif()
 
 if(NOT WIN32 AND NOT APPLE)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../install/linux/resources/meshlab.desktop" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../install/meshlab.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/pixmaps)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../install/meshlab.png" DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
 endif()
 
 if(Qt5_windeployqt_EXECUTABLE AND BUILD_WITH_WINDEPLOYQT_POST_BUILD)


### PR DESCRIPTION
My desktop environment does not load the menu icon if in /usr/share/icons/pixmaps.
No other app has an icon there, so I assume it was incorrect.