### PR TITLE
fix typos found in various files

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -170,7 +170,7 @@ jobs:
       run: |
         cd ..
         git clone --recursive https://github.com/cnr-isti-vclab/meshlab
-    - name: Downlaod Jom
+    - name: Download Jom
       run: |
         Invoke-WebRequest -Uri "http://download.qt.io/official_releases/jom/jom_1_1_3.zip" -OutFile "jom_1_1_3.zip"
         New-Item -Name "jom" -ItemType "directory"

--- a/.github/workflows/BuildWindows.yml
+++ b/.github/workflows/BuildWindows.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Downlaod Jom
+    - name: Download Jom
       run: |
         Invoke-WebRequest -Uri "http://download.qt.io/official_releases/jom/jom_1_1_3.zip" -OutFile "jom_1_1_3.zip"
         New-Item -Name "jom" -ItemType "directory"

--- a/install/linux/README.md
+++ b/install/linux/README.md
@@ -2,9 +2,9 @@
 
 This folder contains a series of scripts to build and deploy MeshLab under a Linux environment.
 
-The follwing scripts are provided:
+The following scripts are provided:
 
-* `linux_setup_env_ubuntu.sh`: this script installs all the required dependecies that are necessary to build MeshLab in an Ubuntu distro (tested in 16.04, 18.04). If you never installed Qt and other libraries, you should run it before any other script;
+* `linux_setup_env_ubuntu.sh`: this script installs all the required dependencies that are necessary to build MeshLab in an Ubuntu distro (tested in 16.04, 18.04). If you never installed Qt and other libraries, you should run it before any other script;
 * `linux_build.sh`: this script compiles MeshLab in a Linux environment:
 	* it requires a properly set Qt environment (see `linux_setup_env_ubuntu.sh`); 
 	* without given arguments, all the binaries will be placed in the `meshlab/distrib` folder. You can give as argument the `BUILD_PATH`, and meshlab binaries will be then placed inside `BUILD_PATH/distrib`;

--- a/install/macos/README.md
+++ b/install/macos/README.md
@@ -2,9 +2,9 @@
 
 This folder contains a series of scripts to build and deploy MeshLab under a MacOS environment.
 
-The follwing scripts are provided:
+The following scripts are provided:
 
-* `macos_setup_env.sh`: this script installs all the required dependecies that are necessary to build MeshLab and create its DMG in a MacOS machine (tested in 10.15 Catalina). It requires [homebrew](https://brew.sh/) installed.
+* `macos_setup_env.sh`: this script installs all the required dependencies that are necessary to build MeshLab and create its DMG in a MacOS machine (tested in 10.15 Catalina). It requires [homebrew](https://brew.sh/) installed.
 * `macos_build.sh`: this script compiles MeshLab in a MacOS environment:
 	* it requires a properly set Qt environment (see `macos_setup_env.sh`); 
 	* without given arguments, all the binaries will be placed in the `meshlab/distrib` folder. You can give as argument the `BUILD_PATH`, and meshlab binaries will be then placed inside `BUILD_PATH/distrib`;

--- a/install/windows/README.md
+++ b/install/windows/README.md
@@ -4,7 +4,7 @@
 
 This folder contains a series of scripts to build and deploy MeshLab under a Windows environment.
 
-The follwing scripts are provided:
+The following scripts are provided:
 
 * `windows_build.ps1`: this script compiles MeshLab in a Windows environment:
 	* it requires a properly set Visual Studio (>=2015) and MSVC compiler; 

--- a/install/windows/resources/windows_nsis_script.ps1
+++ b/install/windows/resources/windows_nsis_script.ps1
@@ -9,7 +9,7 @@
 # After running this script, a meshlab_final.script can be found in the resources folder.
 # This script is ready to be run by makensis.exe
 
-#saving location where script has been runned
+#saving location where script has been run
 $DIR = Get-Location
 
 $INSTALL_PATH = Join-Path $PSScriptRoot ..\

--- a/install/windows/windows_build.ps1
+++ b/install/windows/windows_build.ps1
@@ -9,7 +9,7 @@
 # You can give as argument the BUILD_PATH, and meshlab binaries will be
 # then placed inside BUILD_PATH/distrib.
 
-#saving location where script has been runned
+#saving location where script has been run
 
 write-host "N of arguments: $($args.count)"
 

--- a/install/windows/windows_build_debug.ps1
+++ b/install/windows/windows_build_debug.ps1
@@ -9,7 +9,7 @@
 # You can give as argument the BUILD_PATH, and meshlab binaries will be
 # then placed inside BUILD_PATH/distrib.
 
-#saving location where script has been runned
+#saving location where script has been run
 
 write-host "N of arguments: $($args.count)"
 

--- a/install/windows/windows_deploy.ps1
+++ b/install/windows/windows_deploy.ps1
@@ -10,10 +10,10 @@
 #
 # After running this script, $DISTRIB_PATH will be a portable meshlab folder.
 #
-# To be runned in a windows environment without Visual Studio installed,
+# To be run in a windows environment without Visual Studio installed,
 # vc_redist.exe must be installed before.
 
-#saving location where script has been runned
+#saving location where script has been run
 
 write-host "N of arguments: $($args.count)"
 

--- a/install/windows/windows_nsis_installer.ps1
+++ b/install/windows/windows_nsis_installer.ps1
@@ -9,7 +9,7 @@
 #
 # After running this script, the installer can be found inside the resources folder.
 
-#saving location where script has been runned
+#saving location where script has been run
 $DIR = Get-Location
 
 $INSTALL_PATH = $PSScriptRoot

--- a/src/README.md
+++ b/src/README.md
@@ -4,7 +4,7 @@ In the `src` folder there are several folders containing all the source code and
 
 The source code of MeshLab is structured in the following folders:
 
- * [external](https://github.com/cnr-isti-vclab/meshlab/tree/master/src/external): it contains a series of external libraries needed by several plugins. Some of these libraries are compiled before the compilation of meshlab, if a corresponding systme library is not found and then linked; some other libraries are just included by some plugins.
+ * [external](https://github.com/cnr-isti-vclab/meshlab/tree/master/src/external): it contains a series of external libraries needed by several plugins. Some of these libraries are compiled before the compilation of meshlab, if a corresponding system library is not found and then linked; some other libraries are just included by some plugins.
  * [common](https://github.com/cnr-isti-vclab/meshlab/tree/master/src/common): a series of utility functions used by MeshLab and its plugins.
  * [meshlab](https://github.com/cnr-isti-vclab/meshlab/tree/master/src/meshlab): GUI and core of MeshLab.
  * [meshlabserver](https://github.com/cnr-isti-vclab/meshlab/tree/master/src/meshlabserver): a tool that allows to compute mesh operations through command line
@@ -47,7 +47,7 @@ You can also use [QtCreator](https://www.qt.io/product) to build meshlab:
 1. Install QtCreator and Qt >= 5.9 with `xmlpatterns` as additional package;
 2. Open `meshlab.pro` inside `src`;
 3. Select your favourite shadow build directory;
-4. Before the build, deactive the `QtQuickCompiler` option from the qmake call in the project options;
+4. Before the build, deactivate the `QtQuickCompiler` option from the qmake call in the project options;
 5. Build meshlab.
 
 MeshLab has a plugin architecture and therefore all the plugins are compiled separately; some of them are harder to be compiled. Don't worry, if a plugin fails to compile just remove it and you lose just that functionality. As a first step you should try to compile MeshLab with the configuration "meshlab_mini":

--- a/src/external/muparser_v225/src/muParserTokenReader.cpp
+++ b/src/external/muparser_v225/src/muParserTokenReader.cpp
@@ -771,7 +771,7 @@ namespace mu
   }
 
   //---------------------------------------------------------------------------
-  /** \brief Check wheter a token at a given position is a variable token. 
+  /** \brief Check whether a token at a given position is a variable token. 
       \param a_Tok [out] If a variable token has been found it will be placed here.
 	    \return true if a variable token has been found.
   */
@@ -835,7 +835,7 @@ namespace mu
 
 
   //---------------------------------------------------------------------------
-  /** \brief Check wheter a token at a given position is an undefined variable. 
+  /** \brief Check whether a token at a given position is an undefined variable. 
 
       \param a_Tok [out] If a variable tom_pParser->m_vStringBufken has been found it will be placed here.
 	    \return true if a variable token has been found.
@@ -887,7 +887,7 @@ namespace mu
 
 
   //---------------------------------------------------------------------------
-  /** \brief Check wheter a token at a given position is a string.
+  /** \brief Check whether a token at a given position is a string.
       \param a_Tok [out] If a variable token has been found it will be placed here.
   	  \return true if a string token has been found.
       \sa IsOprt, IsFunTok, IsStrFunTok, IsValTok, IsVarTok, IsEOF, IsInfixOpTok, IsPostOpTok
@@ -920,7 +920,7 @@ namespace mu
 		m_pParser->m_vStringBuf.push_back(strTok); // Store string in internal buffer
     a_Tok.SetString(strTok, m_pParser->m_vStringBuf.size());
 
-    m_iPos += (int)strTok.length() + 2 + (int)iSkip;  // +2 wg Anführungszeichen; +iSkip für entfernte escape zeichen
+    m_iPos += (int)strTok.length() + 2 + (int)iSkip;  // +2 wg Anfï¿½hrungszeichen; +iSkip fï¿½r entfernte escape zeichen
     m_iSynFlags = noANY ^ ( noARG_SEP | noBC | noOPT | noEND );
 
     return true;

--- a/src/general.pri
+++ b/src/general.pri
@@ -1,6 +1,6 @@
 # this is the common include for anything compiled inside the meshlab pro
 # contains general preprocesser, compiler and linker settings,
-# paths for dependecies and so on
+# paths for dependencies and so on
 
 ######## GENERAL SETTINGS ##########
 

--- a/src/meshlab.pro
+++ b/src/meshlab.pro
@@ -294,7 +294,7 @@ edit_pickpoints.depends = common
 # this is just for project info
 # prints all the system libraries that meshlab is using instead of
 # the ones placed in the external folder.
-# The libraris are included effectively in general.pri and
+# The libraries are included effectively in general.pri and
 # in external.pro
 #
 include(find_system_libs.pri)

--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -2231,7 +2231,7 @@ QPair<Shotm,float> GLArea::shotFromTrackball()
 
     float cameraDist = getCameraDistance();
 
-    //add the translation introduced by gluLookAt() (0,0,cameraDist), in order to have te same view---------------
+    //add the translation introduced by gluLookAt() (0,0,cameraDist), in order to have the same view---------------
     //T(gl)*S*R*T(t) => SR(gl+t) => S R (S^(-1)R^(-1)gl + t)
     //Add translation S^(-1) R^(-1)(gl)
     //Shotd doesn't introduce scaling
@@ -2348,7 +2348,7 @@ void GLArea::createOrthoView(QString dir)
 
     float cameraDist = getCameraDistance();
 
-    //add the translation introduced by gluLookAt() (0,0,cameraDist), in order to have te same view---------------
+    //add the translation introduced by gluLookAt() (0,0,cameraDist), in order to have the same view---------------
     //T(gl)*S*R*T(t) => SR(gl+t) => S R (S^(-1)R^(-1)gl + t)
     //Add translation S^(-1) R^(-1)(gl)
     //Shotd doesn't introduce scaling

--- a/src/meshlab/glarea_setting.cpp
+++ b/src/meshlab/glarea_setting.cpp
@@ -24,7 +24,7 @@ void GLAreaSetting::initGlobalParameterSet( RichParameterList * defaultGlobalPar
 	defaultGlobalParamSet->addParam(RichBool(pointSmoothParam()	, false,"Antialiased Point","If true the points are drawn with small circles instead of fast squared dots."));
 	defaultGlobalParamSet->addParam(RichFloat(pointSizeParam()	, 2.0, "Point Size","The base size of points when drawn"));
 
-	defaultGlobalParamSet->addParam(RichBool(wheelDirectionParam(), false, "Wheel Directon", "If true, inverts the direction of the mouse wheel for zooming in/out in the MeshLab canvas."));
+	defaultGlobalParamSet->addParam(RichBool(wheelDirectionParam(), false, "Wheel Direction", "If true, inverts the direction of the mouse wheel for zooming in/out in the MeshLab canvas."));
 }
 
 

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -793,7 +793,7 @@ void MainWindow::runFilterScript()
         RichParameterList &parameterSet = old->pair.second;
 
 		for(RichParameter& parameter : parameterSet) {
-			//if this is a mesh paramter and the index is valid
+			//if this is a mesh parameter and the index is valid
 			if(parameter.value().isMesh()) {
 				RichMesh& md = reinterpret_cast<RichMesh&>(parameter);
 				if( md.meshindex < meshDoc()->size() && md.meshindex >= 0  ) {

--- a/src/meshlabserver/README.md
+++ b/src/meshlabserver/README.md
@@ -12,5 +12,5 @@ In order to be used, MeshLab server usually requires at least three arguments:
 
 A MeshLab script (`*.mlx`) is an XML file that can be read by MeshLab Server, and can contains an ordered set of filters that can be applied to a given input mesh. 
 
-MeshLab scripts can be generated using MeshLab: after loading a mesh, just apply your desired filters and then go to Filters -> Show current filter script. A dialog appers, allowing to see the list of filters applied with the given parameters, that can be also edited. At the end you can save your script that can be then used by MeshLab Server.
+MeshLab scripts can be generated using MeshLab: after loading a mesh, just apply your desired filters and then go to Filters -> Show current filter script. A dialog appears, allowing to see the list of filters applied with the given parameters, that can be also edited. At the end you can save your script that can be then used by MeshLab Server.
 


### PR DESCRIPTION
Found via `codespell v2.0.dev0`

```
codespell -q 3 -S ./src/external,./vcglib,./src/plugins_unsupported/external  -L lod,vertexes
```