### PR TITLE
fix typos found in src/meshlabplugins

### DIFF
--- a/src/meshlabplugins/decorate_base/decorate_base.cpp
+++ b/src/meshlabplugins/decorate_base/decorate_base.cpp
@@ -1143,7 +1143,7 @@ switch(ID(action))
 		parset.addParam(RichBool(this->ShowMeshCameras(), false, "Show Mesh Cameras","if true, valid cameras are shown for all visible mesh layers"));
 		parset.addParam(RichBool(this->ShowRasterCameras(), true, "Show Raster Cameras","if true, valid cameras are shown for all visible raster layers"));
 		parset.addParam(RichBool(this->ShowCameraDetails(), false, "Show Current Camera Details","if true, prints on screen all intrinsics and extrinsics parameters for current camera"));
-		parset.addParam(RichBool(this->ApplyMeshTr(), false, "Apply Current Mesh Matrix", "if true, the poistions of the cameras are mutiplied with the transformation matrix of the current mesh layer"));
+		parset.addParam(RichBool(this->ApplyMeshTr(), false, "Apply Current Mesh Matrix", "if true, the positions of the cameras are mutiplied with the transformation matrix of the current mesh layer"));
 	} break;
 
     case DP_SHOW_QUALITY_CONTOUR :

--- a/src/meshlabplugins/edit_hole/fgtBridge.h
+++ b/src/meshlabplugins/edit_hole/fgtBridge.h
@@ -98,8 +98,8 @@ protected:
 
 
 /** Bridge between different FgtHoles or into the same one.
- *  Bridges rapresent connection between two border edges of different faces.
- *  Connection consists in 2 face adjcent each other over an edge and adjcent
+ *  Bridges represent connection between two border edges of different faces.
+ *  Connection consists in 2 face adjacent each other over an edge and adjacent
  *  with a mesh face over another edge, so both faces have a border edge.
  *
  *  Bridge can connect 2 edge belong the same hole, result are 2 new holes.
@@ -903,7 +903,7 @@ public:
                     }while(p0.v != p1.v);
 
                     // p2 is used only in case face added close sub-hole, sub-hole distance is 2
-                    // p2 is half-edge adjcent to connect to patch edge which usually is border
+                    // p2 is half-edge adjacent to connect to patch edge which usually is border
                     PosType p2 = p0;
                     p2.FlipV();
                     p2.NextB();

--- a/src/meshlabplugins/edit_hole/fgtHole.h
+++ b/src/meshlabplugins/edit_hole/fgtHole.h
@@ -43,7 +43,7 @@
  *  This class also allows one to fill (and restore) an hole using different criteria.
  *
  *  FgtHole uses meshe's additional data to mark interesting face, so surfing 
- *  the hole faces is driven by face-face ajacency and mark meaning.
+ *  the hole faces is driven by face-face adjacency and mark meaning.
  *  Additional data are accessible for an hole by parentManager (HoleSetManager)
  *  which links hole to a mesh.
  *  Characteristic faces for an hole are marked as:
@@ -336,7 +336,7 @@ public:
 		return false;
 	};
 
-	/*  walk over hole border, watching each adiacent faces to its vertex
+	/*  walk over hole border, watching each adjacent faces to its vertex
 	 *  looking for bridge faces.
 	 */ 
 	void UpdateBridgingStatus()

--- a/src/meshlabplugins/edit_mutualcorrs/edit_mutualcorrsDialog.cpp
+++ b/src/meshlabplugins/edit_mutualcorrs/edit_mutualcorrsDialog.cpp
@@ -193,7 +193,7 @@ void edit_mutualcorrsDialog::on_tableWidget_itemChanged(QTableWidgetItem *item)
 void edit_mutualcorrsDialog::on_tableWidget_cellDoubleClicked(int row, int column)
 {
     this->mutualcorrsPlugin->status_error = "";
-    // only significative for forst column, to toggle between active<->inactive
+    // only significative for first column, to toggle between active<->inactive
     if(column == 0)
     {
         this->mutualcorrsPlugin->usePoint[row] = !(this->mutualcorrsPlugin->usePoint[row]);

--- a/src/meshlabplugins/edit_paint/edit_paint.cpp
+++ b/src/meshlabplugins/edit_paint/edit_paint.cpp
@@ -834,7 +834,7 @@ inline void EditPaintPlugin::paint(vector< pair<CVertexO *, PickingData> > * ver
 
 inline void EditPaintPlugin::computeNoiseColor(CVertexO * vert, vcg::Color4b & col)
 {
-	float scaler = noise_scale; //parameter TODO to be cahced
+	float scaler = noise_scale; //parameter TODO to be cached
 
 	double noise;
 	//if "veins on"

--- a/src/meshlabplugins/edit_quality/eqhandle.h
+++ b/src/meshlabplugins/edit_quality/eqhandle.h
@@ -56,7 +56,7 @@ public:
 	QRectF boundingRect () const;
 	virtual void paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget); 
 	
-	void setSize						(int size)					{(size%2==0) ? _size=size+1 : _size=size;}; // Size should be aleays odd
+	void setSize						(int size)					{(size%2==0) ? _size=size+1 : _size=size;}; // Size should be always odd
 	void setBarHeight					(qreal height)				{_barHeight = height;};
 	void setType						(EQUALIZER_HANDLE_TYPE type){_type = type;};	
 	void setMidHandlePercentilePosition (qreal* pointer)			{_midHandlePercentilePosition = pointer;};	

--- a/src/meshlabplugins/filter_colorproc/filter_colorproc.cpp
+++ b/src/meshlabplugins/filter_colorproc/filter_colorproc.cpp
@@ -127,7 +127,7 @@ QString FilterColorProc::pluginName() const
 {
   switch(filterId)
   {
-	case CP_FILLING: return QString("Fills the color of the vertices of the mesh  with a color choosed by the user.");
+	case CP_FILLING: return QString("Fills the color of the vertices of the mesh with a color chosen by the user.");
 	case CP_THRESHOLDING: return QString("Colors the vertices of the mesh using two colors according to a lightness threshold (on the original color).");
 	case CP_CONTR_BRIGHT: return QString("Change the color the vertices of the mesh adjusting brightness, contrast and gamma.");
 	case CP_INVERT: return QString("Inverts the colors of the vertices of the mesh.");

--- a/src/meshlabplugins/filter_fractal/craters_utils.h
+++ b/src/meshlabplugins/filter_fractal/craters_utils.h
@@ -169,7 +169,7 @@ public:
         }
     }
 
-    /* Detectes the faces of a crater starting from a given face, using FF adjacency. */
+    /* Detects the faces of a crater starting from a given face, using FF adjacency. */
     static void GetCraterFaces(MeshType *m,              // target mesh
                                FacePointer startingFace, // face under the crater centre
                                VertexPointer centre,     // crater centre
@@ -291,7 +291,7 @@ public:
         SampleFaceVector sfv;
         CratersUtils<MeshType>::FindSamplesFaces(args.target_mesh, args.samples_mesh, sfv);
 
-        // detectes crater faces and applies the radial perturbation
+        // detects crater faces and applies the radial perturbation
         int cratersNo = int(args.samples_mesh->vert.size()), currentCrater = 0;
         char buffer[50];
         typename SampleFaceVector::iterator sfvi;

--- a/src/meshlabplugins/filter_globalregistration/globalregistration.cpp
+++ b/src/meshlabplugins/filter_globalregistration/globalregistration.cpp
@@ -55,7 +55,7 @@ QString GlobalRegistrationPlugin::filterName(FilterIDType filterId) const
  QString GlobalRegistrationPlugin::filterInfo(FilterIDType filterId) const
 {
   switch(filterId) {
-        case FP_GLOBAL_REGISTRATION :  return QString("Compute the rigid transforation aligning two 3d objets.");
+        case FP_GLOBAL_REGISTRATION :  return QString("Compute the rigid transformation aligning two 3d objects.");
         default : assert(0);
     }
     return QString("Unknown Filter");

--- a/src/meshlabplugins/filter_isoparametrization/texcoord_optimization.h
+++ b/src/meshlabplugins/filter_isoparametrization/texcoord_optimization.h
@@ -64,7 +64,7 @@ public:
   // initializes on current geometry 
   virtual void TargetCurrentGeometry()=0;
   
-  // performs an interation. Returns largest movement.
+  // performs an iteration. Returns largest movement.
   virtual ScalarType Iterate()=0;
   
   // performs an iteration (faster, but it does not tell how close it is to stopping)

--- a/src/meshlabplugins/filter_sampling/filter_sampling.cpp
+++ b/src/meshlabplugins/filter_sampling/filter_sampling.cpp
@@ -466,7 +466,7 @@ void FilterDocSampling::initParameterSet(QAction *action, MeshDocument & md, Ric
   case FP_MONTECARLO_SAMPLING :
     parlst.addParam(RichInt ("SampleNum", md.mm()->cm.vn,
                                  "Number of samples",
-                                 "The desired number of samples. It can be smaller or larger than the mesh size, and according to the choosed sampling strategy it will try to adapt."));
+                                 "The desired number of samples. It can be smaller or larger than the mesh size, and according to the chosen sampling strategy it will try to adapt."));
     parlst.addParam(RichBool("Weighted",  false,
                                  "Quality Weighted Sampling",
                                  "Use per vertex quality to drive the vertex sampling. The number of samples falling in each face is proportional to the face area multiplied by the average quality of the face vertices."));
@@ -485,7 +485,7 @@ void FilterDocSampling::initParameterSet(QAction *action, MeshDocument & md, Ric
   case FP_STRATIFIED_SAMPLING :
     parlst.addParam(RichInt ("SampleNum",  std::max(100000,md.mm()->cm.vn),
                                  "Number of samples",
-                                 "The desired number of samples. It can be smaller or larger than the mesh size, and according to the choosed sampling strategy it will try to adapt."));
+                                 "The desired number of samples. It can be smaller or larger than the mesh size, and according to the chosen sampling strategy it will try to adapt."));
     parlst.addParam(RichEnum("Sampling", 0,
                                  QStringList() << "Similar Triangle" << "Dual Similar Triangle" << "Long Edge Subdiv" << "Sample Edges" << "Sample NonFaux Edges",
                                  tr("Element to sample:"),
@@ -579,7 +579,7 @@ void FilterDocSampling::initParameterSet(QAction *action, MeshDocument & md, Ric
 		parlst.addParam(RichBool("SampleFauxEdge", false, "Sample FauxEdge", "See the above comment."));
 		parlst.addParam(RichBool("SampleFace", false, "Sample Faces", "See the above comment."));
 		parlst.addParam(RichInt("SampleNum", md.mm()->cm.vn, "Number of samples",
-			"The desired number of samples. It can be smaller or larger than the mesh size, and according to the choosed sampling strategy it will try to adapt."));
+			"The desired number of samples. It can be smaller or larger than the mesh size, and according to the chosen sampling strategy it will try to adapt."));
 		parlst.addParam(RichAbsPerc("MaxDist", md.mm()->cm.bbox.Diag() / 2.0, 0.0f, md.bbox().Diag(),
 			tr("Max Distance"), tr("Sample points for which we do not find anything within this distance are rejected and not considered neither for averaging nor for max.")));
   } break;

--- a/src/meshlabplugins/filter_screened_poisson/Src/Array.inl
+++ b/src/meshlabplugins/filter_screened_poisson/Src/Array.inl
@@ -185,7 +185,7 @@ public:
 		}
 		else
 		{
-			// [WARNING] Chaning szC and szD to size_t causes some really strange behavior.
+			// [WARNING] Changing szC and szD to size_t causes some really strange behavior.
 			long long szC = sizeof( C );
 			long long szD = sizeof( D );
 			data = (C*)a.data;
@@ -398,7 +398,7 @@ public:
 	template< class D >
 	inline ConstArray( const ConstArray< D >& a )
 	{
-		// [WARNING] Chaning szC and szD to size_t causes some really strange behavior.
+		// [WARNING] Changing szC and szD to size_t causes some really strange behavior.
 		long long szC = sizeof( C );
 		long long szD = sizeof( D );
 		data = ( const C*)a.pointer( );

--- a/src/meshlabplugins/filter_trioptimize/curvedgeflip.h
+++ b/src/meshlabplugins/filter_trioptimize/curvedgeflip.h
@@ -300,7 +300,7 @@ public:
         // The priority of an edge flip is **how much we lower the overall curvature**.
         // If after the flip the sum of the curvature is decreased it is a good move;
         // good flips have:    cafter < cbefore
-        // Since the local optimization is designed to make the miniumum cost move we put inside
+        // Since the local optimization is designed to make the minimum cost move we put inside
         // negative values (the more negative the better).
         this->_priority = (cafter - cbefore);
         //qDebug("computed curvature change, %f->%f (priority = %f)", cbefore,cafter,this->_priority);

--- a/src/meshlabplugins/filter_voronoi/filter_voronoi.cpp
+++ b/src/meshlabplugins/filter_voronoi/filter_voronoi.cpp
@@ -151,7 +151,7 @@ void FilterVoronoiPlugin::initParameterSet(QAction* action, MeshModel& m, RichPa
 									"barycenter of the region. Over a surface we have two different strategies: <ul>"
 									"<li> Geodesic: the seed is placed onto the vertex that maximize the geodesic distance from the border of the region </li>"
 									"<li> Squared Distance: the seed is placed in the vertex that minimize the squared sum of the distances from all the pints of the region.</li>"
-									"<li> Restricted: the seed is placed in the barycenter of current voronoi region. Even if it is outside the surface. During the relaxation process the seed is free to move off the surface in a continuos way. Re-association to vertex is done at the end..</li>"
+									"<li> Restricted: the seed is placed in the barycenter of current voronoi region. Even if it is outside the surface. During the relaxation process the seed is free to move off the surface in a continuous way. Re-association to vertex is done at the end..</li>"
 									"</ul>"));
 		 break;
 	 case VOLUME_SAMPLING:

--- a/src/meshlabplugins/io_3ds/io_3ds.h
+++ b/src/meshlabplugins/io_3ds/io_3ds.h
@@ -42,7 +42,7 @@ public:
     cb=0;
   }
 
-	/// It returns a bit mask describing the field preesnt in the ply file
+	/// It returns a bit mask describing the field present in the ply file
   int mask;  
 
   /// a Simple callback that can be used for long obj parsing. 

--- a/src/meshlabplugins/io_bre/io_bre.cpp
+++ b/src/meshlabplugins/io_bre/io_bre.cpp
@@ -605,7 +605,7 @@ int vcg::tri::io::ReadBreElementsInGrid( QFile &file, VertexGrid &grid, CMeshO &
   
   //creating mesh
   //going through the whole grid, testing if Valid. 
-  //Only Points that are valid and have enough valid neigbours to form a triangle will be added.
+  //Only Points that are valid and have enough valid neighbours to form a triangle will be added.
   
   float cbstep = ((float)(80)/(float)(num));//for the progress bar
   float cbvalue = 0.f;//for the progress bar

--- a/src/meshlabplugins/io_x3d/util_x3d.h
+++ b/src/meshlabplugins/io_x3d/util_x3d.h
@@ -179,7 +179,7 @@ namespace io {
 				"Invalid save color options. You must choose one options among color per vertex, color per face and color per wedge",
 				"Invalid save normal options. You must choose one options among normal per vertex, normal per face and normal per wedge",
 				"Invalid save texture coordinate options. You must choose one options among texture coordinate per vertex and texture coordinate per wedge",
-				"Mesh whitout a geometry"
+				"Mesh without a geometry"
 			};
 
 			if(error > 31 || error < 0) return "Unknown error";

--- a/src/meshlabplugins/io_x3d/vrml/Scanner.frame
+++ b/src/meshlabplugins/io_x3d/vrml/Scanner.frame
@@ -188,7 +188,7 @@ public:
 };
 
 //-----------------------------------------------------------------------------------
-// StartStates  -- maps charactes to start states of tokens
+// StartStates  -- maps characters to start states of tokens
 //-----------------------------------------------------------------------------------
 class StartStates {
 private:


### PR DESCRIPTION
Follow up to #78  
Found via `codespell v2.0.dev0`

```
codespell -q 3 -S ./src/external,./vcglib,./src/plugins_unsupported/external  -L lod,vertexes src/meshlabplugins/
```

Omitted translating 'trasform, traslate, and closests'