### PR TITLE
Fix depthmap shader coloring

### DIFF
--- a/distrib/shaders/depthmap.frag
+++ b/distrib/shaders/depthmap.frag
@@ -39,5 +39,5 @@ void main()
 	vec4 v = vec4(vpos);
 	v /= v.w;
 	float gray = (v.z - zmin) / (zmax - zmin);
-	gl_FragColor = vec4(gray);
+	gl_FragColor = vec4(vec3(gray), 1.0);
 }


### PR DESCRIPTION
I'm brand new here, but I was trying to use the depthmap.gdp shader and
wasn't seeing the results I expected. Poking around the fragment shader,
I noticed the `gray` value was used for red, green, blue *and* alpha
channels, meaning values towards 0 (black) won't be displayed as
expected. My wild guess is that this worked when the alpha channel was
ignored, but for me on MacOS it was definitely not working.

Using the `gray` value for red/green/blue and 1.0 for alpha fixes it.