### PR TITLE
use snap extension

### DIFF
--- a/scripts/Linux/resources/snap/snap_noversion.yaml
+++ b/scripts/Linux/resources/snap/snap_noversion.yaml
@@ -16,41 +16,14 @@ confinement: strict
 
 apps:
   meshlab:
-    command: desktop-launch $SNAP/AppRun
-    plugs: [home, x11, mir, opengl, removable-media]
+    command: AppRun
+    extensions: [kde-neon]
+    plugs: [home, opengl, removable-media]
     desktop: usr/share/applications/meshlab.desktop
 
 
 parts:
-  desktop-qt5:
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-      - dpkg-dev
-    make-parameters:
-      - FLAVOR=qt5
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: qt
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libqt5qml5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5
-      - try:
-        - appmenu-qt5
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5
   meshlab:
-    after: [desktop-qt5]
     plugin: qmake
     qt-version: qt5
     source: https://github.com/cnr-isti-vclab/meshlab.git
@@ -69,15 +42,18 @@ parts:
       - libqhull-dev
       - patchelf
       - rsync
+      - libqt5opengl5-dev
     stage-packages:
       - lib3ds-1-3
       - libgomp1
       - libopenctm1
       - libqhull7
-      - libglew-dev
-      - libqt5opengl5-dev
-      - qtdeclarative5-dev
       - libqt5gui5
+      - qtwayland5
+      - libglu1-mesa
+      - libopengl0
+      - libqt5opengl5
+      - libqt5xml5
     override-build: |
       sh scripts/Linux/1_build.sh
       sh scripts/Linux/resources/make_bundle.sh

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,8 +16,8 @@ confinement: strict
 
 apps:
   meshlab:
-    command: desktop-launch $SNAP/AppRun
-    plugs: [home, x11, mir, opengl, removable-media]
+    command: bin/desktop-launch $SNAP/AppRun
+    plugs: [home, desktop, wayland, x11, opengl, removable-media]
     desktop: usr/share/applications/meshlab.desktop
 
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,41 +16,14 @@ confinement: strict
 
 apps:
   meshlab:
-    command: bin/desktop-launch $SNAP/AppRun
-    plugs: [home, desktop, wayland, x11, opengl, removable-media]
+    command: AppRun
+    extensions: [kde-neon]
+    plugs: [home, opengl, removable-media]
     desktop: usr/share/applications/meshlab.desktop
 
 
 parts:
-  desktop-qt5:
-    build-packages:
-      - build-essential
-      - qtbase5-dev
-      - dpkg-dev
-    make-parameters:
-      - FLAVOR=qt5
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: qt
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libqt5qml5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5
-      - try:
-        - appmenu-qt5
-      - locales-all
-      - xdg-user-dirs
-      - fcitx-frontend-qt5
   meshlab:
-    after: [desktop-qt5]
     plugin: qmake
     qt-version: qt5
     source: https://github.com/cnr-isti-vclab/meshlab.git

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -69,15 +69,18 @@ parts:
       - libqhull-dev
       - patchelf
       - rsync
+      - libqt5opengl5-dev
     stage-packages:
       - lib3ds-1-3
       - libgomp1
       - libopenctm1
       - libqhull7
-      - libglew-dev
-      - libqt5opengl5-dev
-      - qtdeclarative5-dev
       - libqt5gui5
+      - qtwayland5
+      - libglu1-mesa
+      - libopengl0
+      - libqt5opengl5
+      - libqt5xml5
     override-build: |
       sh scripts/Linux/1_build.sh
       sh scripts/Linux/resources/make_bundle.sh

--- a/src/common/GLExtensionsManager.cpp
+++ b/src/common/GLExtensionsManager.cpp
@@ -61,7 +61,7 @@ void GLExtensionsManager::initializeGLextensions()
     if (!glewInitialized) {
         glewExperimental = GL_TRUE;
         GLenum err = glewInit();
-        if (err != GLEW_OK) {
+        if (err != GLEW_OK && err != GLEW_ERROR_NO_GLX_DISPLAY) {
             throw MLException(QString("GLEW initialization failed: %1\n")
                                   .arg((const char *)glewGetErrorString(err)));
         }

--- a/src/find_system_libs.pri
+++ b/src/find_system_libs.pri
@@ -41,11 +41,6 @@ linux {
     exists(/usr/include/eigen3){
         CONFIG += system_eigen3
     }
-
-    #glew
-    exists(/usr/include/GL/glew.h){
-        CONFIG += system_glew
-    }
 }
 
 }


### PR DESCRIPTION
The [snapcraft-desktop-helpers](https://github.com/ubuntu/snapcraft-desktop-helpers) seem to be deprecated in favour of toolkit specific [extensions](https://forum.snapcraft.io/t/snapcraft-extensions/13486). There is an additional change to make meshlab work on Wayland.

I actually tried to make the xdg-desktop-portal work, as suggested in https://github.com/cnr-isti-vclab/meshlab/issues/466#issuecomment-710119913. According to https://forum.snapcraft.io/t/xdg-desktop-portals/17331, this should work when using extensions but I still could not open files from `/tmp` via the file dialog.