### PR TITLE
Possibility to load extra plugins

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,7 +177,7 @@ else()
 		meshlabplugins/filter_dirt
 		meshlabplugins/filter_fractal
 		meshlabplugins/filter_func
-		meshlabplugins/filter_globalregistration
+		#meshlabplugins/filter_globalregistration
 		meshlabplugins/filter_img_patch_param
 		meshlabplugins/filter_isoparametrization
 		meshlabplugins/filter_layer

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,14 +52,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ### Build Settings
-if (BUILD_WITH_DOUBLE_SCALAR)
-	message(STATUS "Building with double precision")
-	add_definitions(-DMESHLAB_SCALAR=double)
-else()
-	message(STATUS "Building with single precision")
-	add_definitions(-DMESHLAB_SCALAR=float)
-endif()
-
 if(WIN32)
 	add_definitions(-DNOMINMAX)
 	if(MSVC)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADERS
 	plugins/interfaces/ioraster_plugin_interface.h
 	plugins/interfaces/plugin_interface.h
 	plugins/interfaces/render_plugin_interface.h
+	plugins/meshlab_plugin_type.h
 	plugins/plugin_manager_iterators.h
 	plugins/plugin_manager.h
 	ml_document/helpers/mesh_document_state_data.h
@@ -50,6 +51,7 @@ set(SOURCES
 	plugins/interfaces/decorate_plugin_interface.cpp
 	plugins/interfaces/filter_plugin_interface.cpp
 	plugins/interfaces/plugin_interface.cpp
+	plugins/meshlab_plugin_type.cpp
 	plugins/plugin_manager.cpp
 	ml_document/helpers/mesh_document_state_data.cpp
 	ml_document/cmesh.cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 set(HEADERS
 	globals.h
+	plugins/interfaces/plugin_file_interface.h
 	plugins/interfaces/decorate_plugin_interface.h
 	plugins/interfaces/edit_plugin_interface.h
 	plugins/interfaces/filter_plugin_interface.h

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -3,8 +3,18 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../ML_VERSION")
 	if (BUILD_WITH_DOUBLE_SCALAR)
 		set(MESHLAB_VERSION "${MESHLAB_VERSION}d")
 	endif()
-	add_definitions(-DMESHLAB_VERSION=${MESHLAB_VERSION})
+	#add_definitions(-DMESHLAB_VERSION=${MESHLAB_VERSION})
 	message(STATUS "MeshLab version: ${MESHLAB_VERSION}")
+endif()
+
+if (BUILD_WITH_DOUBLE_SCALAR)
+	message(STATUS "Building with double precision")
+	set(MESHLAB_SCALAR "double")
+	#add_definitions(-DMESHLAB_SCALAR=double)
+else()
+	message(STATUS "Building with single precision")
+	set(MESHLAB_SCALAR "float")
+	#add_definitions(-DMESHLAB_SCALAR=float)
 endif()
 
 set(HEADERS
@@ -80,6 +90,11 @@ if(WIN32)
 	set(TARGET_TYPE STATIC)
 endif()
 add_library(meshlab-common ${TARGET_TYPE} ${SOURCES} ${HEADERS} ${RESOURCES})
+
+target_compile_definitions(meshlab-common 
+	PUBLIC 
+		MESHLAB_VERSION=${MESHLAB_VERSION}
+		MESHLAB_SCALAR=${MESHLAB_SCALAR})
 
 target_include_directories(meshlab-common
 	PRIVATE

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADERS
 	plugins/interfaces/ioraster_plugin_interface.h
 	plugins/interfaces/plugin_interface.h
 	plugins/interfaces/render_plugin_interface.h
+	plugins/plugin_manager_iterators.h
 	plugins/plugin_manager.h
 	ml_document/helpers/mesh_document_state_data.h
 	ml_document/helpers/mesh_model_state_data.h

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -48,6 +48,7 @@ HEADERS += 	\
 	plugins/interfaces/iomesh_plugin_interface.h \
 	plugins/interfaces/plugin_interface.h \
 	plugins/interfaces/render_plugin_interface.h \
+	plugins/meshlab_plugin_type.h \
 	plugins/plugin_manager_iterators.h \
 	plugins/plugin_manager.h \
 	ml_document/helpers/mesh_document_state_data.h \
@@ -79,6 +80,7 @@ SOURCES += \
 	plugins/interfaces/decorate_plugin_interface.cpp \
 	plugins/interfaces/filter_plugin_interface.cpp \
 	plugins/interfaces/plugin_interface.cpp \
+	plugins/meshlab_plugin_type.cpp \
 	plugins/plugin_manager.cpp \
 	ml_document/helpers/mesh_document_state_data.cpp \
 	ml_document/cmesh.cpp \

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -31,12 +31,7 @@ INCLUDEPATH *= \
 	DEFINES += GLEW_STATIC
 }
 
-# defining meshlab version
-exists(../../ML_VERSION){
-	MESHLAB_VERSION = $$cat(../../ML_VERSION)
-	message(MeshLab Version: $$MESHLAB_VERSION)
-	DEFINES += "MESHLAB_VERSION=$$MESHLAB_VERSION"
-}
+message(MeshLab Version: $$MESHLAB_VERSION)
 
 # Input
 HEADERS += 	\

--- a/src/common/common.pro
+++ b/src/common/common.pro
@@ -41,12 +41,15 @@ exists(../../ML_VERSION){
 # Input
 HEADERS += 	\
 	globals.h \
+	plugins/interfaces/plugin/file/interface.h \
 	plugins/interfaces/decorate_plugin_interface.h \
 	plugins/interfaces/edit_plugin_interface.h \
 	plugins/interfaces/filter_plugin_interface.h \
 	plugins/interfaces/iomesh_plugin_interface.h \
 	plugins/interfaces/plugin_interface.h \
 	plugins/interfaces/render_plugin_interface.h \
+	plugins/plugin_manager_iterators.h \
+	plugins/plugin_manager.h \
 	ml_document/helpers/mesh_document_state_data.h \
 	ml_document/helpers/mesh_model_state_data.h \
 	ml_document/base_types.h \
@@ -64,7 +67,6 @@ HEADERS += 	\
 	filterscript.h \
 	GLLogStream.h \
 	mainwindow_interface.h \
-	plugins/plugin_manager.h \
 	mlexception.h \
 	mlapplication.h \
 	meshlabdocumentxml.h \
@@ -77,6 +79,7 @@ SOURCES += \
 	plugins/interfaces/decorate_plugin_interface.cpp \
 	plugins/interfaces/filter_plugin_interface.cpp \
 	plugins/interfaces/plugin_interface.cpp \
+	plugins/plugin_manager.cpp \
 	ml_document/helpers/mesh_document_state_data.cpp \
 	ml_document/cmesh.cpp \
 	ml_document/mesh_model.cpp \
@@ -90,7 +93,6 @@ SOURCES += \
 	GLExtensionsManager.cpp \
 	filterscript.cpp \
 	GLLogStream.cpp \
-	plugins/plugin_manager.cpp \
 	mlapplication.cpp \
 	searcher.cpp \
 	meshlabdocumentxml.cpp \

--- a/src/common/globals.h
+++ b/src/common/globals.h
@@ -29,6 +29,13 @@
 
 #include <QString>
 
+#ifndef MESHLAB_VERSION
+#error "MESHLAB_VERSION needs to be defined!"
+#endif
+#ifndef MESHLAB_SCALAR
+#error "MESHLAB_SCALAR needs to be defined!"
+#endif
+
 class RichParameterList;
 class PluginManager;
 

--- a/src/common/mlapplication.cpp
+++ b/src/common/mlapplication.cpp
@@ -1,6 +1,8 @@
 #include "mlapplication.h"
 #include "mlexception.h"
 #include <vcg/complex/complex.h>
+#include <QStandardPaths>
+#include <QDir>
 #include "globals.h"
 
 #ifndef MESHLAB_VERSION
@@ -55,6 +57,21 @@ const QString MeshLabApplication::compilerVersion()
 const QString MeshLabApplication::qtVersion()
 {
 	return QString(QT_VERSION_STR);
+}
+
+const QString MeshLabApplication::extraPluginsLocation()
+{
+	QDir appDir(QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).first());
+	appDir.mkpath(appDir.absolutePath());
+	
+	appDir.mkdir("MeshLabExtraPlugins");
+	appDir.cd("MeshLabExtraPlugins");
+	
+	QString major = appVer().left(4);
+	appDir.mkdir(major);
+	appDir.cd(major);
+	
+	return appDir.absolutePath();
 }
 
 std::string MeshLabApplication::versionString(int a, int b, int c)

--- a/src/common/mlapplication.h
+++ b/src/common/mlapplication.h
@@ -34,6 +34,8 @@ public:
 	static const QString versionRegisterKeyName() {return tr("version");}
 	static const QString wordSizeKeyName() {return tr("wordSize");}
 	
+	static const QString extraPluginsLocation();
+	
 private:
 	static std::string versionString(int a, int b, int c);
 };

--- a/src/common/plugins/interfaces/decorate_plugin_interface.h
+++ b/src/common/plugins/interfaces/decorate_plugin_interface.h
@@ -112,15 +112,6 @@ protected:
 	virtual FilterIDType ID(QString name) const;
 };
 
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-	   public: \
-		   virtual std::pair<std::string, bool> getMLVersion() const { \
-			   return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-		   } \
-	   private: 
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
-
 #define DECORATE_PLUGIN_INTERFACE_IID  "vcg.meshlab.MeshDecorateInterface/1.0"
 Q_DECLARE_INTERFACE(DecoratePluginInterface, DECORATE_PLUGIN_INTERFACE_IID)
 

--- a/src/common/plugins/interfaces/edit_plugin_interface.h
+++ b/src/common/plugins/interfaces/edit_plugin_interface.h
@@ -122,16 +122,7 @@ public:
 		virtual std::pair<std::string, bool> getMLVersion() const { \
 			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
 		} \
-	private: 
-
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-	public: \
-		virtual std::pair<std::string, bool> getMLVersion() const { \
-			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-		} \
 	private:
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
 
 #define EDIT_PLUGIN_INTERFACE_IID  "vcg.meshlab.EditPluginInterface/1.0"
 #define EDIT_PLUGIN_INTERFACE_FACTORY_IID  "vcg.meshlab.EditPluginInterfaceFactory/1.0"

--- a/src/common/plugins/interfaces/edit_plugin_interface.h
+++ b/src/common/plugins/interfaces/edit_plugin_interface.h
@@ -91,7 +91,7 @@ public:
 	virtual void tabletEvent(QTabletEvent * e, MeshModel &/*m*/, GLArea *) { e->ignore(); }
 	
 private:
-	virtual QString pluginName() const {return QString();};
+	virtual QString pluginName() const final {return QString();};
 };
 
 
@@ -101,15 +101,11 @@ private:
 This is needed because editing filters have a internal state, so if you want to have an editing tool for two different documents you have to instance two objects.
 This class is used by the framework to generate an independent MeshEditInterface for each document.
 */
-class EditPluginInterfaceFactory
+class EditPluginInterfaceFactory : public PluginFileInterface
 {
 public:
+	EditPluginInterfaceFactory() {}
 	virtual ~EditPluginInterfaceFactory() {}
-
-	virtual std::pair<std::string, bool> getMLVersion() const  = 0;
-	
-	//returns the plugin name
-	virtual QString pluginName() const = 0;
 
 	//gets a list of actions available from this plugin
 	virtual QList<QAction *> actions() const = 0;

--- a/src/common/plugins/interfaces/filter_plugin_interface.h
+++ b/src/common/plugins/interfaces/filter_plugin_interface.h
@@ -233,15 +233,6 @@ protected:
 	QString errorMessage;
 };
 
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-		   public: \
-			   virtual std::pair<std::string, bool> getMLVersion() const { \
-				   return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-			   } \
-		   private: 
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
-
 #define FILTER_PLUGIN_INTERFACE_IID  "vcg.meshlab.FilterPluginInterface/1.0"
 Q_DECLARE_INTERFACE(FilterPluginInterface, FILTER_PLUGIN_INTERFACE_IID)
 

--- a/src/common/plugins/interfaces/iomesh_plugin_interface.h
+++ b/src/common/plugins/interfaces/iomesh_plugin_interface.h
@@ -103,15 +103,6 @@ protected:
 
 };
 
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-	public: \
-		virtual std::pair<std::string, bool> getMLVersion() const { \
-			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-		} \
-	private: 
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
-
 #define IOMESH_PLUGIN_INTERFACE_IID "vcg.meshlab.IOMeshPluginInterface/1.0"
 Q_DECLARE_INTERFACE(IOMeshPluginInterface, IOMESH_PLUGIN_INTERFACE_IID)
 

--- a/src/common/plugins/interfaces/ioraster_plugin_interface.h
+++ b/src/common/plugins/interfaces/ioraster_plugin_interface.h
@@ -59,15 +59,6 @@ protected:
 	QString errorMessage;
 };
 
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-	public: \
-		virtual std::pair<std::string, bool> getMLVersion() const { \
-			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-		} \
-	private: 
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
-
 #define IORASTER_PLUGIN_INTERFACE_IID "vcg.meshlab.IORasterPluginInterface/1.0"
 Q_DECLARE_INTERFACE(IORasterPluginInterface, IORASTER_PLUGIN_INTERFACE_IID)
 

--- a/src/common/plugins/interfaces/plugin_file_interface.h
+++ b/src/common/plugins/interfaces/plugin_file_interface.h
@@ -53,11 +53,18 @@ public:
 	virtual std::pair<std::string, bool> getMLVersion() const  = 0;
 	
 	/**
-	 * @brief This functions returns the name of the current plugin.
+	 * @brief This function returns the name of the current plugin.
 	 * Must be implemented in every plugin.
 	 * @return
 	 */
 	virtual QString pluginName() const = 0;
+	
+	/**
+	 * @brief This function returns the vendor (developer or organization)
+	 * of the plugin. 
+	 * @return 
+	 */
+	//virtual QString vendor() const = 0;
 	
 	bool isEnabled() const {return enabled;}
 	void enable() {enabled = true;}
@@ -69,5 +76,14 @@ private:
 	bool enabled;
 	QFileInfo plugFileInfo;
 };
+
+#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
+	Q_PLUGIN_METADATA(IID x) \
+	public: \
+		virtual std::pair<std::string, bool> getMLVersion() const { \
+			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
+		} \
+	private: 
+#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
 
 #endif // MESHLAB_PLUGIN_FILE_INTERFACE_H

--- a/src/common/plugins/interfaces/plugin_file_interface.h
+++ b/src/common/plugins/interfaces/plugin_file_interface.h
@@ -67,12 +67,12 @@ public:
 	virtual QString vendor() const {return "CNR-ISTI VCLab";};
 	
 	bool isEnabled() const {return enabled;}
-	void enable() {enabled = true;}
-	void disable() {enabled = false;}
 
 	QFileInfo pluginFileInfo() const {return plugFileInfo;}
 
 private:
+	void enable() {enabled = true;}
+	void disable() {enabled = false;}
 	bool enabled;
 	QFileInfo plugFileInfo;
 };

--- a/src/common/plugins/interfaces/plugin_file_interface.h
+++ b/src/common/plugins/interfaces/plugin_file_interface.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005-2021                                           \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#ifndef MESHLAB_PLUGIN_FILE_INTERFACE_H
+#define MESHLAB_PLUGIN_FILE_INTERFACE_H
+
+#include <string>
+#include <QFileInfo>
+#include <QString>
+
+/**
+ * @brief The PluginFileInterface class is the base of all MeshLab plugin classes,
+ * and represents the library file of the plugin.
+ * Each MeshLab plugin can then be a classic plugin (and inherit from the PluginInterface class)
+ * or a collection of Edit plugins (and inherit from the EditPluginInterfaceFactory class).
+ * Each Plugin (classic or edit) inherits from this class. 
+ */
+class PluginFileInterface
+{
+public:
+	friend class PluginManager;
+	
+	PluginFileInterface() : enabled(true) {};
+	virtual ~PluginFileInterface() {}
+	
+	/** 
+	 * This function will be automatically defined in your plugin class
+	 * when you use the MESHLAB_PLUGIN_IID_EXPORTER macro.
+	 * The only exception is for the Edit plugins (not EditFactory!):
+	 * in this case, this function is defined by the macro
+	 * MESHLAB_EDIT_PLUGIN
+	 **/
+	virtual std::pair<std::string, bool> getMLVersion() const  = 0;
+	
+	/**
+	 * @brief This functions returns the name of the current plugin.
+	 * Must be implemented in every plugin.
+	 * @return
+	 */
+	virtual QString pluginName() const = 0;
+	
+	bool isEnabled() const {return enabled;}
+	void enable() {enabled = true;}
+	void disable() {enabled = false;}
+
+	QFileInfo pluginFileInfo() const {return plugFileInfo;}
+
+private:
+	bool enabled;
+	QFileInfo plugFileInfo;
+};
+
+#endif // MESHLAB_PLUGIN_FILE_INTERFACE_H

--- a/src/common/plugins/interfaces/plugin_file_interface.h
+++ b/src/common/plugins/interfaces/plugin_file_interface.h
@@ -64,7 +64,7 @@ public:
 	 * of the plugin. 
 	 * @return 
 	 */
-	//virtual QString vendor() const = 0;
+	virtual QString vendor() const {return "CNR-ISTI VCLab";};
 	
 	bool isEnabled() const {return enabled;}
 	void enable() {enabled = true;}

--- a/src/common/plugins/interfaces/plugin_interface.cpp
+++ b/src/common/plugins/interfaces/plugin_interface.cpp
@@ -1,13 +1,33 @@
 #include "plugin_interface.h"
 
 PluginInterface::PluginInterface() :
-    logstream(nullptr)
+    logstream(nullptr), enabled(true)
 {
 }
 
 void PluginInterface::setLog(GLLogStream* log)
 {
 	this->logstream = log;
+}
+
+bool PluginInterface::isEnabled() const
+{
+	return enabled;
+}
+
+void PluginInterface::enable()
+{
+	enabled = true;
+}
+
+void PluginInterface::disable()
+{
+	enabled = false;
+}
+
+QFileInfo PluginInterface::pluginFileInfo() const
+{
+	return plugFileInfo;
 }
 
 void PluginInterface::log(const char* s)

--- a/src/common/plugins/interfaces/plugin_interface.cpp
+++ b/src/common/plugins/interfaces/plugin_interface.cpp
@@ -1,33 +1,13 @@
 #include "plugin_interface.h"
 
 PluginInterface::PluginInterface() :
-    logstream(nullptr), enabled(true)
+    logstream(nullptr)
 {
 }
 
 void PluginInterface::setLog(GLLogStream* log)
 {
 	this->logstream = log;
-}
-
-bool PluginInterface::isEnabled() const
-{
-	return enabled;
-}
-
-void PluginInterface::enable()
-{
-	enabled = true;
-}
-
-void PluginInterface::disable()
-{
-	enabled = false;
-}
-
-QFileInfo PluginInterface::pluginFileInfo() const
-{
-	return plugFileInfo;
 }
 
 void PluginInterface::log(const char* s)

--- a/src/common/plugins/interfaces/plugin_interface.h
+++ b/src/common/plugins/interfaces/plugin_interface.h
@@ -25,7 +25,7 @@
 #define MESHLAB_PLUGIN_INTERFACE_H
 
 #include <QAction>
-
+#include <QFileInfo>
 
 #include "../../GLLogStream.h"
 #include "../../parameters/rich_parameter_list.h"
@@ -46,6 +46,8 @@
 class PluginInterface
 {
 public:
+	friend class PluginManager;
+	
 	typedef int FilterIDType;
 
 	/** the type used to identify plugin actions; there is a one-to-one relation between an ID and an Action.
@@ -72,6 +74,12 @@ public:
 
 	/// Standard stuff that usually should not be redefined.
 	void setLog(GLLogStream* log);
+	
+	bool isEnabled() const;
+	void enable();
+	void disable();
+	
+	QFileInfo pluginFileInfo() const;
 
 	// This function must be used to communicate useful information collected in the parsing/saving of the files.
 	// NEVER EVER use a msgbox to say something to the user.
@@ -97,6 +105,8 @@ public:
 
 private:
 	GLLogStream *logstream;
+	bool enabled;
+	QFileInfo plugFileInfo;
 };
 
 /************************

--- a/src/common/plugins/interfaces/plugin_interface.h
+++ b/src/common/plugins/interfaces/plugin_interface.h
@@ -2,7 +2,7 @@
 * MeshLab                                                           o o     *
 * A versatile mesh processing toolbox                             o     o   *
 *                                                                _   O  _   *
-* Copyright(C) 2005-2020                                           \/)\/    *
+* Copyright(C) 2005-2021                                           \/)\/    *
 * Visual Computing Lab                                            /\/|      *
 * ISTI - Italian National Research Council                           |      *
 *                                                                    \      *
@@ -25,8 +25,8 @@
 #define MESHLAB_PLUGIN_INTERFACE_H
 
 #include <QAction>
-#include <QFileInfo>
 
+#include "plugin_file_interface.h"
 #include "../../GLLogStream.h"
 #include "../../parameters/rich_parameter_list.h"
 #include "../../globals.h"
@@ -43,11 +43,9 @@
  *
  * \todo There is inconsistency in the usage of ID and actions for retrieving particular filters. Remove.
  */
-class PluginInterface
+class PluginInterface : public PluginFileInterface
 {
 public:
-	friend class PluginManager;
-	
 	typedef int FilterIDType;
 
 	/** the type used to identify plugin actions; there is a one-to-one relation between an ID and an Action.
@@ -56,30 +54,8 @@ public:
 	PluginInterface();
 	virtual ~PluginInterface() {}
 
-	/** 
-	 * This function will be automatically defined in your plugin class
-	 * when you use the MESHLAB_PLUGIN_IID_EXPORTER macro.
-	 * The only exception is for the Edit plugins (not EditFactory!):
-	 * in this case, this function is defined by the macro
-	 * MESHLAB_EDIT_PLUGIN
-	 **/
-	virtual std::pair<std::string, bool> getMLVersion() const  = 0;
-	
-	/**
-	 * @brief This functions returns the name of the current plugin.
-	 * Must be implemented in every plugin.
-	 * @return
-	 */
-	virtual QString pluginName() const = 0;
-
 	/// Standard stuff that usually should not be redefined.
 	void setLog(GLLogStream* log);
-	
-	bool isEnabled() const;
-	void enable();
-	void disable();
-	
-	QFileInfo pluginFileInfo() const;
 
 	// This function must be used to communicate useful information collected in the parsing/saving of the files.
 	// NEVER EVER use a msgbox to say something to the user.
@@ -105,8 +81,6 @@ public:
 
 private:
 	GLLogStream *logstream;
-	bool enabled;
-	QFileInfo plugFileInfo;
 };
 
 /************************

--- a/src/common/plugins/interfaces/render_plugin_interface.h
+++ b/src/common/plugins/interfaces/render_plugin_interface.h
@@ -62,15 +62,6 @@ public:
 	virtual QList<QAction *> actions() = 0;
 };
 
-#define MESHLAB_PLUGIN_IID_EXPORTER(x) \
-	Q_PLUGIN_METADATA(IID x) \
-	public: \
-		virtual std::pair<std::string, bool> getMLVersion() const { \
-			return std::make_pair(meshlab::meshlabVersion(), meshlab::builtWithDoublePrecision()); \
-		} \
-	private: 
-#define MESHLAB_PLUGIN_NAME_EXPORTER(x)
-
 #define RENDER_PLUGIN_INTERFACE_IID  "vcg.meshlab.RenderPluginInterface/1.0"
 Q_DECLARE_INTERFACE(RenderPluginInterface, RENDER_PLUGIN_INTERFACE_IID)
 

--- a/src/common/plugins/meshlab_plugin_type.cpp
+++ b/src/common/plugins/meshlab_plugin_type.cpp
@@ -1,0 +1,150 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005-2021                                           \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#include "meshlab_plugin_type.h"
+
+#include "interfaces/decorate_plugin_interface.h"
+#include "interfaces/edit_plugin_interface.h"
+#include "interfaces/filter_plugin_interface.h"
+#include "interfaces/iomesh_plugin_interface.h"
+#include "interfaces/ioraster_plugin_interface.h"
+#include "interfaces/render_plugin_interface.h"
+
+MeshLabPluginType::MeshLabPluginType(const PluginFileInterface* fpi) : type(0)
+{
+	//Decorate
+	const DecoratePluginInterface *iDecorator = dynamic_cast<const DecoratePluginInterface *>(fpi);
+	if (iDecorator) {
+		type |= DECORATE;
+	}
+	//EditFactory
+	const EditPluginInterfaceFactory* efp = dynamic_cast<const EditPluginInterfaceFactory *>(fpi);
+	if (efp) { //EditFactory Plugin
+		type |= EDIT;
+	}
+	//Filter
+	const FilterPluginInterface *iFilter = dynamic_cast<const FilterPluginInterface *>(fpi);
+	if (iFilter){
+		type |= FILTER;
+	}
+	//IOMesh
+	const IOMeshPluginInterface *iIOMesh = dynamic_cast<const IOMeshPluginInterface *>(fpi);
+	if (iIOMesh) {
+		type |= IO_MESH;
+	}
+	//IORaster
+	const IORasterPluginInterface* iIORaster = dynamic_cast<const IORasterPluginInterface*>(fpi);
+	if (iIORaster) {
+		type |= IO_RASTER;
+	}
+	
+	//Render
+	const RenderPluginInterface *iRender = dynamic_cast<const RenderPluginInterface *>(fpi);
+	if (iRender) {
+		type |= RENDER;
+	}
+
+	if (type == 0)
+		type = UNKNOWN;
+}
+
+bool MeshLabPluginType::isValid() const
+{
+	return !(type & UNKNOWN);
+}
+
+bool MeshLabPluginType::isDecoratePlugin() const
+{
+	return type & DECORATE;
+}
+
+bool MeshLabPluginType::isEditPlugin() const
+{
+	return type & EDIT;
+}
+
+bool MeshLabPluginType::isFilterPlugin() const
+{
+	return type & FILTER;
+}
+
+bool MeshLabPluginType::isIOMeshPlugin() const
+{
+	return type & IO_MESH;
+}
+
+bool MeshLabPluginType::isIORasterPlugin() const
+{
+	return type & IO_RASTER;
+}
+
+bool MeshLabPluginType::isRenderPlugin() const
+{
+	return type & RENDER;
+}
+
+bool MeshLabPluginType::isMultipleTypePlugin() const
+{
+	if (type == UNKNOWN) return false;
+	return ((type & (type - 1)) != 0); //true if not power of 2
+}
+
+/**
+ * @brief Returns a string representing the type of the plugin.
+ * Note: 
+ * - returns "Unknown" it the type is not valid;
+ * - returns a String of the type "Type1|Type2" if the plugin
+ *   has multiple types.
+ * @return 
+ */
+QString MeshLabPluginType::pluginTypeString() const
+{
+	QString type = "";
+	if (!isValid())
+		return "Unknown";
+	
+	if (isDecoratePlugin()){
+		type += "Decorate";
+	}
+	if (isEditPlugin()){
+		if (!type.isEmpty()) type += "|";
+		type += "Edit";
+	}
+	if (isFilterPlugin()){
+		if (!type.isEmpty()) type += "|";
+		type += "Filter";
+	}
+	if (isIOMeshPlugin()){
+		if (!type.isEmpty()) type += "|";
+		type += "IOMesh";
+	}
+	if (isIORasterPlugin()){
+		if (!type.isEmpty()) type += "|";
+		type += "IORaster";
+	}
+	if (isRenderPlugin()){
+		if (!type.isEmpty()) type += "|";
+		type += "Render";
+	}
+	return type;
+}

--- a/src/common/plugins/meshlab_plugin_type.h
+++ b/src/common/plugins/meshlab_plugin_type.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005-2021                                           \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#ifndef MESHLAB_PLUGIN_TYPE_H
+#define MESHLAB_PLUGIN_TYPE_H
+
+class QString;
+
+class PluginFileInterface;
+
+class MeshLabPluginType
+{
+public:
+	MeshLabPluginType(const PluginFileInterface* fpi);
+
+	bool isValid() const;
+	bool isDecoratePlugin() const;
+	bool isEditPlugin() const;
+	bool isFilterPlugin() const;
+	bool isIOMeshPlugin() const;
+	bool isIORasterPlugin() const;
+	bool isRenderPlugin() const;
+
+	bool isMultipleTypePlugin() const;
+	QString pluginTypeString() const;
+
+private:
+	enum MLPType {
+		UNKNOWN   = 1<<0, //1
+		DECORATE  = 1<<1, //2
+		EDIT      = 1<<2, //4
+		FILTER    = 1<<3, //8
+		IO_MESH   = 1<<4, //16
+		IO_RASTER = 1<<5, //32
+		RENDER    = 1<<6  //64
+	};
+
+	int type;
+};
+
+#endif // MESHLAB_PLUGIN_TYPE_H

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -184,6 +184,11 @@ const QStringList& PluginManager::inputRasterFormatListDialog() const
 	return inputRasterFormatsDialogStringList;
 }
 
+PluginFileInterface* PluginManager::operator[](unsigned int i) const
+{
+	return allPlugins[i];
+}
+
 PluginManager::PluginRangeIterator PluginManager::pluginIterator() const
 {
 	return PluginRangeIterator(this);

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -130,8 +130,19 @@ void PluginManager::loadPlugin(const QString& fileName)
 	if (!ifp){
 		throw MLException(fin.fileName() + " is not a MeshLab plugin.");
 	}
-	if (ifp && ifp->getMLVersion().second != MeshLabScalarTest<Scalarm>::doublePrecision()) {
+	if (ifp->getMLVersion().second != MeshLabScalarTest<Scalarm>::doublePrecision()) {
 		throw MLException(fin.fileName() + " has different floating point precision from the running MeshLab version.");
+	}
+	std::string mlVersionPlug = ifp->getMLVersion().first;
+	std::string majorVersionPlug = mlVersionPlug.substr(0, 4); //4 is the position of '.' in meshlab version
+	std::string majorVersionML = meshlab::meshlabVersion().substr(0, 4);
+	if (majorVersionML != majorVersionPlug){
+		throw MLException(fin.fileName() + " has different major version from the running MeshLab version.");
+	}
+	std::string minorVersionPlug = mlVersionPlug.substr(5, mlVersionPlug.size());
+	std::string minorVersionML = meshlab::meshlabVersion().substr(5, meshlab::meshlabVersion().size());
+	if (std::stoi(minorVersionPlug) > std::stoi(minorVersionML)){
+		throw MLException(fin.fileName() + " has greater version from the running MeshLab version. Please update MeshLab to use it.");
 	}
 	
 	//TODO: check in some way also the meshlab version of the plugin

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -184,7 +184,7 @@ const QStringList& PluginManager::inputRasterFormatListDialog() const
 	return inputRasterFormatsDialogStringList;
 }
 
-PluginManager::PluginRangeIterator PluginManager::namePluginPairIterator() const
+PluginManager::PluginRangeIterator PluginManager::pluginIterator() const
 {
 	return PluginRangeIterator(this);
 }

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -265,39 +265,39 @@ PluginFileInterface* PluginManager::operator[](unsigned int i) const
 	return allPlugins[i];
 }
 
-PluginManager::PluginRangeIterator PluginManager::pluginIterator() const
+PluginManager::PluginRangeIterator PluginManager::pluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return PluginRangeIterator(this);
+	return PluginRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::FilterPluginRangeIterator PluginManager::filterPluginIterator() const
+PluginManager::FilterPluginRangeIterator PluginManager::filterPluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return FilterPluginRangeIterator(this);
+	return FilterPluginRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::IOMeshPluginIterator PluginManager::ioMeshPluginIterator() const
+PluginManager::IOMeshPluginIterator PluginManager::ioMeshPluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return IOMeshPluginIterator(this);
+	return IOMeshPluginIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::IORasterPluginIterator PluginManager::ioRasterPluginIterator() const
+PluginManager::IORasterPluginIterator PluginManager::ioRasterPluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return IORasterPluginIterator(this);
+	return IORasterPluginIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::RenderPluginRangeIterator PluginManager::renderPluginIterator() const
+PluginManager::RenderPluginRangeIterator PluginManager::renderPluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return RenderPluginRangeIterator(this);
+	return RenderPluginRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::DecoratePluginRangeIterator PluginManager::decoratePluginIterator() const
+PluginManager::DecoratePluginRangeIterator PluginManager::decoratePluginIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return DecoratePluginRangeIterator(this);
+	return DecoratePluginRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
-PluginManager::EditPluginFactoryRangeIterator PluginManager::editPluginFactoryIterator() const
+PluginManager::EditPluginFactoryRangeIterator PluginManager::editPluginFactoryIterator(bool iterateAlsoDisabledPlugins) const
 {
-	return EditPluginFactoryRangeIterator(this);
+	return EditPluginFactoryRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
 void PluginManager::loadFilterPlugin(FilterPluginInterface* iFilter, const QString& fileName)

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -251,6 +251,7 @@ bool PluginManager::loadPlugin(const QString& fileName)
 	//TODO: check in some way also the meshlab version of the plugin
 	
 	if (ip) { //Classic MeshLab plugin (non Edit...)
+		ip->plugFileInfo = fin;
 		bool loadOk = false;
 		//FilterPlugin
 		FilterPluginInterface *iFilter = qobject_cast<FilterPluginInterface *>(plugin);

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -59,7 +59,7 @@ PluginManager::~PluginManager()
 	decoratePlugins.clear();
 	editPlugins.clear();
 	for (auto& plugin : allPlugins)
-		delete plugin.second;
+		delete plugin;
 	allPlugins.clear();
 }
 
@@ -184,9 +184,9 @@ const QStringList& PluginManager::inputRasterFormatListDialog() const
 	return inputRasterFormatsDialogStringList;
 }
 
-PluginManager::NamePluginPairRangeIterator PluginManager::namePluginPairIterator() const
+PluginManager::PluginRangeIterator PluginManager::namePluginPairIterator() const
 {
-	return NamePluginPairRangeIterator(this);
+	return PluginRangeIterator(this);
 }
 
 PluginManager::FilterPluginRangeIterator PluginManager::filterPluginIterator() const
@@ -265,11 +265,8 @@ bool PluginManager::loadPlugin(const QString& fileName)
 	}
 
 	if (loadOk){ //If the plugin has been loaded correctly
-		if (allPlugins.find(ifp->pluginName()) != allPlugins.end()) {
-			qDebug() << "Warning: " << ifp->pluginName() << " has been already loaded.";
-		}
 		ifp->plugFileInfo = fin;
-		allPlugins[ifp->pluginName()] = ifp;
+		allPlugins.push_back(ifp);
 	}
 
 	return loadOk;

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -158,22 +158,22 @@ void PluginManager::loadPlugin(const QString& fileName)
 	MeshLabPluginType type(ifp);
 	
 	if (type.isDecoratePlugin()){
-		loadDecoratePlugin(qobject_cast<DecoratePluginInterface *>(plugin), fileName);
+		loadDecoratePlugin(qobject_cast<DecoratePluginInterface *>(plugin));
 	}
 	if (type.isEditPlugin()){
-		loadEditPlugin(qobject_cast<EditPluginInterfaceFactory *>(plugin), fileName);
+		loadEditPlugin(qobject_cast<EditPluginInterfaceFactory *>(plugin));
 	}
 	if (type.isFilterPlugin()){
-		loadFilterPlugin(qobject_cast<FilterPluginInterface *>(plugin), fileName);
+		loadFilterPlugin(qobject_cast<FilterPluginInterface *>(plugin));
 	}
 	if (type.isIOMeshPlugin()){
-		loadIOMeshPlugin(qobject_cast<IOMeshPluginInterface *>(plugin), fileName);
+		loadIOMeshPlugin(qobject_cast<IOMeshPluginInterface *>(plugin));
 	}
 	if (type.isIORasterPlugin()){
-		loadIORasterPlugin(qobject_cast<IORasterPluginInterface*>(plugin), fileName);
+		loadIORasterPlugin(qobject_cast<IORasterPluginInterface*>(plugin));
 	}
 	if (type.isRenderPlugin()){
-		loadRenderPlugin(qobject_cast<RenderPluginInterface *>(plugin), fileName);
+		loadRenderPlugin(qobject_cast<RenderPluginInterface *>(plugin));
 	}
 
 	//set the QFileInfo to the plugin, and add it to the continer
@@ -286,73 +286,17 @@ QStringList PluginManager::inputRasterFormatList() const
 
 QStringList PluginManager::inputMeshFormatListDialog() const
 {
-	QString allKnownFormats = QObject::tr("All known formats (");
-	QStringList inputMeshFormatsDialogStringList;
-	for (IOMeshPluginInterface* ioMesh : ioMeshPluginIterator()){
-		QString allKnownFormatsFilter;
-		for (const FileFormat& currentFormat : ioMesh->importFormats()){
-			QString currentFilterEntry = currentFormat.description + " (";
-			for (QString currentExtension : currentFormat.extensions) {
-				currentExtension = currentExtension.toLower();
-				allKnownFormatsFilter.append(QObject::tr(" *."));
-				allKnownFormatsFilter.append(currentExtension);
-				currentFilterEntry.append(QObject::tr(" *."));
-				currentFilterEntry.append(currentExtension);
-			}
-			currentFilterEntry.append(')');
-			inputMeshFormatsDialogStringList.append(currentFilterEntry);
-		}
-		allKnownFormats += allKnownFormatsFilter;
-	}
-	allKnownFormats.append(')');
-	inputMeshFormatsDialogStringList.push_front(allKnownFormats);
-	return inputMeshFormatsDialogStringList;
+	return inputFormatListDialog(ioMeshPluginIterator());
 }
 
 QStringList PluginManager::outputMeshFormatListDialog() const
 {
-	QStringList outputMeshFormatsDialogStringList;
-	for (IOMeshPluginInterface* ioMesh : ioMeshPluginIterator()){
-		QString allKnownFormatsFilter;
-		for (const FileFormat& currentFormat : ioMesh->exportFormats()){
-			QString currentFilterEntry = currentFormat.description + " (";
-			for (QString currentExtension : currentFormat.extensions) {
-				currentExtension = currentExtension.toLower();
-				allKnownFormatsFilter.append(QObject::tr(" *."));
-				allKnownFormatsFilter.append(currentExtension);
-				currentFilterEntry.append(QObject::tr(" *."));
-				currentFilterEntry.append(currentExtension);
-			}
-			currentFilterEntry.append(')');
-			outputMeshFormatsDialogStringList.append(currentFilterEntry);
-		}
-	}
-	return outputMeshFormatsDialogStringList;
+	return outputFormatListDialog(ioMeshPluginIterator());
 }
 
 QStringList PluginManager::inputRasterFormatListDialog() const
 {
-	QString allKnownFormats = QObject::tr("All known formats (");
-	QStringList inputRasterFormatsDialogStringList;
-	for (IORasterPluginInterface* ioRaster : ioRasterPluginIterator()){
-		QString allKnownFormatsFilter;
-		for (const FileFormat& currentFormat : ioRaster->importFormats()){
-			QString currentFilterEntry = currentFormat.description + " (";
-			for (QString currentExtension : currentFormat.extensions) {
-				currentExtension = currentExtension.toLower();
-				allKnownFormatsFilter.append(QObject::tr(" *."));
-				allKnownFormatsFilter.append(currentExtension);
-				currentFilterEntry.append(QObject::tr(" *."));
-				currentFilterEntry.append(currentExtension);
-			}
-			currentFilterEntry.append(')');
-			inputRasterFormatsDialogStringList.append(currentFilterEntry);
-		}
-		allKnownFormats += allKnownFormatsFilter;
-	}
-	allKnownFormats.append(')');
-	inputRasterFormatsDialogStringList.push_front(allKnownFormats);
-	return inputRasterFormatsDialogStringList;
+	return inputFormatListDialog(ioRasterPluginIterator());
 }
 
 PluginFileInterface* PluginManager::operator[](unsigned int i) const
@@ -395,23 +339,23 @@ PluginManager::EditPluginFactoryRangeIterator PluginManager::editPluginFactoryIt
 	return EditPluginFactoryRangeIterator(this, iterateAlsoDisabledPlugins);
 }
 
-void PluginManager::loadFilterPlugin(FilterPluginInterface* iFilter, const QString& fileName)
+void PluginManager::loadFilterPlugin(FilterPluginInterface* iFilter)
 {
 	for(QAction *filterAction : iFilter->actions()) {
 		if(iFilter->getClass(filterAction)==FilterPluginInterface::Generic){
-			throw MLException("Missing class for " +fileName + " " + filterAction->text());
+			throw MLException("Missing class for " + iFilter->pluginName() + " " + filterAction->text());
 		}
 		if(iFilter->getRequirements(filterAction) == int(MeshModel::MM_UNKNOWN)){
-			throw MLException("Missing requirements for " +fileName + " " + filterAction->text());
+			throw MLException("Missing requirements for " + iFilter->pluginName() + " " + filterAction->text());
 		}
 		if(iFilter->getPreConditions(filterAction) == int(MeshModel::MM_UNKNOWN)){
-			throw MLException("Missing preconditions for "+fileName + " " + filterAction->text());
+			throw MLException("Missing preconditions for "+ iFilter->pluginName() + " " + filterAction->text());
 		}
 		if(iFilter->postCondition(filterAction) == int(MeshModel::MM_UNKNOWN)) {
-			throw MLException("Missing postcondition for "+fileName + " " + filterAction->text());
+			throw MLException("Missing postcondition for "+ iFilter->pluginName() + " " + filterAction->text());
 		}
 		if(iFilter->filterArity(filterAction) == FilterPluginInterface::UNKNOWN_ARITY) {
-			throw MLException("Missing Arity for " +fileName + " " + filterAction->text());
+			throw MLException("Missing Arity for " + iFilter->pluginName() + " " + filterAction->text());
 		}
 	}
 
@@ -422,7 +366,7 @@ void PluginManager::loadFilterPlugin(FilterPluginInterface* iFilter, const QStri
 	filterPlugins.push_back(iFilter);
 }
 
-void PluginManager::loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh, const QString&)
+void PluginManager::loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh)
 {
 	ioMeshPlugins.push_back(iIOMesh);
 
@@ -445,7 +389,7 @@ void PluginManager::loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh, const QStri
 	}
 }
 
-void PluginManager::loadIORasterPlugin(IORasterPluginInterface* iIORaster, const QString&)
+void PluginManager::loadIORasterPlugin(IORasterPluginInterface* iIORaster)
 {
 	ioRasterPlugins.push_back(iIORaster);
 	
@@ -459,7 +403,7 @@ void PluginManager::loadIORasterPlugin(IORasterPluginInterface* iIORaster, const
 	}
 }
 
-void PluginManager::loadDecoratePlugin(DecoratePluginInterface* iDecorate, const QString&)
+void PluginManager::loadDecoratePlugin(DecoratePluginInterface* iDecorate)
 {
 	decoratePlugins.push_back(iDecorate);
 	for(QAction *decoratorAction : iDecorate->actions()) {
@@ -467,12 +411,57 @@ void PluginManager::loadDecoratePlugin(DecoratePluginInterface* iDecorate, const
 	}
 }
 
-void PluginManager::loadRenderPlugin(RenderPluginInterface* iRender, const QString&)
+void PluginManager::loadRenderPlugin(RenderPluginInterface* iRender)
 {
 	renderPlugins.push_back(iRender);
 }
 
-void PluginManager::loadEditPlugin(EditPluginInterfaceFactory* iEditFactory, const QString&)
+void PluginManager::loadEditPlugin(EditPluginInterfaceFactory* iEditFactory)
 {
 	editPlugins.push_back(iEditFactory);
+}
+
+template<typename RangeIterator>
+QStringList PluginManager::inputFormatListDialog(RangeIterator iterator)
+{
+	QString allKnownFormats = QObject::tr("All known formats (");
+	QStringList inputRasterFormatsDialogStringList;
+	for (auto ioRaster : iterator){
+		QString allKnownFormatsFilter;
+		for (const FileFormat& currentFormat : ioRaster->importFormats()){
+			QString currentFilterEntry = currentFormat.description + " (";
+			for (QString currentExtension : currentFormat.extensions) {
+				currentExtension = currentExtension.toLower();
+				allKnownFormatsFilter.append(QObject::tr(" *."));
+				allKnownFormatsFilter.append(currentExtension);
+				currentFilterEntry.append(QObject::tr(" *."));
+				currentFilterEntry.append(currentExtension);
+			}
+			currentFilterEntry.append(')');
+			inputRasterFormatsDialogStringList.append(currentFilterEntry);
+		}
+		allKnownFormats += allKnownFormatsFilter;
+	}
+	allKnownFormats.append(')');
+	inputRasterFormatsDialogStringList.push_front(allKnownFormats);
+	return inputRasterFormatsDialogStringList;
+}
+
+template<typename RangeIterator>
+QStringList PluginManager::outputFormatListDialog(RangeIterator iterator)
+{
+	QStringList inputRasterFormatsDialogStringList;
+	for (auto ioRaster : iterator){
+		for (const FileFormat& currentFormat : ioRaster->exportFormats()){
+			QString currentFilterEntry = currentFormat.description + " (";
+			for (QString currentExtension : currentFormat.extensions) {
+				currentExtension = currentExtension.toLower();
+				currentFilterEntry.append(QObject::tr(" *."));
+				currentFilterEntry.append(currentExtension);
+			}
+			currentFilterEntry.append(')');
+			inputRasterFormatsDialogStringList.append(currentFilterEntry);
+		}
+	}
+	return inputRasterFormatsDialogStringList;
 }

--- a/src/common/plugins/plugin_manager.cpp
+++ b/src/common/plugins/plugin_manager.cpp
@@ -21,7 +21,7 @@
 *                                                                           *
 ****************************************************************************/
 
-#include "plugin_manager.h"
+#include "plugin_manager_iterators.h" //includes plugin_manager.h
 #include <QObject>
 #include <qapplication.h>
 #include <QPluginLoader>

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -56,6 +56,8 @@ public:
 	/** Member functions **/
 	void loadPlugins();
 	void loadPlugins(const QDir& pluginsDirectory);
+	void loadPlugin(const QString& filename);
+	
 	QString pluginsCode() const;
 
 	unsigned int size() const;
@@ -119,16 +121,13 @@ private:
 
 	//Edit Plugins
 	std::vector<EditPluginInterfaceFactory*> editPlugins;
-
-	//Private member functions
-	bool loadPlugin(const QString& filename);
 	
-	bool loadFilterPlugin(FilterPluginInterface* iFilter, const QString& fileName);
-	bool loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh, const QString& fileName);
-	bool loadIORasterPlugin(IORasterPluginInterface* iIORaster, const QString& fileName);
-	bool loadDecoratePlugin(DecoratePluginInterface* iDecorate, const QString& fileName);
-	bool loadRenderPlugin(RenderPluginInterface* iRender, const QString& fileName);
-	bool loadEditPlugin(EditPluginInterfaceFactory* iEditFactory, const QString& fileName);
+	void loadFilterPlugin(FilterPluginInterface* iFilter, const QString& fileName);
+	void loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh, const QString& fileName);
+	void loadIORasterPlugin(IORasterPluginInterface* iIORaster, const QString& fileName);
+	void loadDecoratePlugin(DecoratePluginInterface* iDecorate, const QString& fileName);
+	void loadRenderPlugin(RenderPluginInterface* iRender, const QString& fileName);
+	void loadEditPlugin(EditPluginInterfaceFactory* iEditFactory, const QString& fileName);
 	
 	void fillKnownIOFormats();
 

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -76,9 +76,9 @@ public:
 	QStringList inputMeshFormatList() const;
 	QStringList outputMeshFormatList() const;
 	QStringList inputRasterFormatList() const;
-	const QStringList& inputMeshFormatListDialog() const;
-	const QStringList& outputMeshFormatListDialog() const;
-	const QStringList& inputRasterFormatListDialog() const;
+	QStringList inputMeshFormatListDialog() const;
+	QStringList outputMeshFormatListDialog() const;
+	QStringList inputRasterFormatListDialog() const;
 	
 	PluginFileInterface* operator [](unsigned int i) const;
 
@@ -101,13 +101,10 @@ private:
 	std::vector<IOMeshPluginInterface*> ioMeshPlugins;
 	QMap<QString,IOMeshPluginInterface*> inputMeshFormatToPluginMap;
 	QMap<QString,IOMeshPluginInterface*> outputMeshFormatToPluginMap;
-	QStringList inputMeshFormatsDialogStringList; //todo: remove this
-	QStringList outputMeshFormatsDialogStringList; //todo: remove this
 
 	//IORasterPlugins
 	std::vector<IORasterPluginInterface*> ioRasterPlugins;
 	QMap<QString, IORasterPluginInterface*> inputRasterFormatToPluginMap;
-	QStringList inputRasterFormatsDialogStringList;
 
 	//Filter Plugins
 	std::vector<FilterPluginInterface*> filterPlugins;

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -43,7 +43,17 @@ class PluginManager
 public:
 	PluginManager();
 	~PluginManager();
-	
+
+	/** Iterators (definitions can be found in plugin_manager_iterators.h) **/ 
+	class NamePluginPairRangeIterator;
+	class FilterPluginRangeIterator;
+	class IOMeshPluginIterator;
+	class IORasterPluginIterator;
+	class RenderPluginRangeIterator;
+	class DecoratePluginRangeIterator;
+	class EditPluginFactoryRangeIterator;
+
+	/** Member functions **/
 	void loadPlugins();
 	void loadPlugins(const QDir& pluginsDirectory);
 	QString pluginsCode() const;
@@ -68,83 +78,7 @@ public:
 	const QStringList& outputMeshFormatListDialog() const;
 	const QStringList& inputRasterFormatListDialog() const;
 
-	class NamePluginPairRangeIterator
-	{
-		friend class PluginManager;
-	public:
-		std::map<QString, PluginInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
-		std::map<QString, PluginInterface*>::const_iterator end() {return pm->allPlugins.end();}
-	private:
-		NamePluginPairRangeIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class FilterPluginRangeIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<FilterPluginInterface*>::const_iterator begin() {return pm->filterPlugins.begin();}
-		QVector<FilterPluginInterface*>::const_iterator end() {return pm->filterPlugins.end();}
-	private:
-		FilterPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class IOMeshPluginIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<IOMeshPluginInterface*>::const_iterator begin() {return pm->ioMeshPlugins.begin();}
-		QVector<IOMeshPluginInterface*>::const_iterator end() {return pm->ioMeshPlugins.end();}
-	private:
-		IOMeshPluginIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class IORasterPluginIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<IORasterPluginInterface*>::const_iterator begin() {return pm->ioRasterPlugins.begin();}
-		QVector<IORasterPluginInterface*>::const_iterator end() {return pm->ioRasterPlugins.end();}
-	private:
-		IORasterPluginIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class RenderPluginRangeIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<RenderPluginInterface*>::const_iterator begin() {return pm->renderPlugins.begin();}
-		QVector<RenderPluginInterface*>::const_iterator end() {return pm->renderPlugins.end();}
-	private:
-		RenderPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class DecoratePluginRangeIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<DecoratePluginInterface*>::const_iterator begin() {return pm->decoratePlugins.begin();}
-		QVector<DecoratePluginInterface*>::const_iterator end() {return pm->decoratePlugins.end();}
-	private:
-		DecoratePluginRangeIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
-	class EditPluginFactoryRangeIterator
-	{
-		friend class PluginManager;
-	public:
-		QVector<EditPluginInterfaceFactory*>::const_iterator begin() {return pm->editPlugins.begin();}
-		QVector<EditPluginInterfaceFactory*>::const_iterator end() {return pm->editPlugins.end();}
-	private:
-		EditPluginFactoryRangeIterator(const PluginManager* pm) : pm(pm) {}
-		const PluginManager* pm;
-	};
-
+	/** Member functions for range iterators **/
 	NamePluginPairRangeIterator namePluginPairIterator() const;
 	FilterPluginRangeIterator filterPluginIterator() const;
 	IOMeshPluginIterator ioMeshPluginIterator() const;
@@ -208,5 +142,7 @@ private:
 			IOMeshPluginInterface* pMeshIOPlugin,
 			const QList<FileFormat>& format);
 };
+
+#include "plugin_manager_iterators.h"
 
 #endif // MESHLAB_PLUGIN_MANAGER_H

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -122,12 +122,18 @@ private:
 	//Edit Plugins
 	std::vector<EditPluginInterfaceFactory*> editPlugins;
 	
-	void loadFilterPlugin(FilterPluginInterface* iFilter, const QString& fileName);
-	void loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh, const QString& fileName);
-	void loadIORasterPlugin(IORasterPluginInterface* iIORaster, const QString& fileName);
-	void loadDecoratePlugin(DecoratePluginInterface* iDecorate, const QString& fileName);
-	void loadRenderPlugin(RenderPluginInterface* iRender, const QString& fileName);
-	void loadEditPlugin(EditPluginInterfaceFactory* iEditFactory, const QString& fileName);
+	void loadFilterPlugin(FilterPluginInterface* iFilter);
+	void loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh);
+	void loadIORasterPlugin(IORasterPluginInterface* iIORaster);
+	void loadDecoratePlugin(DecoratePluginInterface* iDecorate);
+	void loadRenderPlugin(RenderPluginInterface* iRender);
+	void loadEditPlugin(EditPluginInterfaceFactory* iEditFactory);
+	
+	template <typename RangeIterator>
+	static QStringList inputFormatListDialog(RangeIterator iterator);
+	
+	template <typename RangeIterator>
+	static QStringList outputFormatListDialog(RangeIterator iterator);
 };
 
 #include "plugin_manager_iterators.h"

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -45,7 +45,7 @@ public:
 	~PluginManager();
 
 	/** Iterators (definitions can be found in plugin_manager_iterators.h) **/ 
-	class NamePluginPairRangeIterator;
+	class PluginRangeIterator;
 	class FilterPluginRangeIterator;
 	class IOMeshPluginIterator;
 	class IORasterPluginIterator;
@@ -79,7 +79,7 @@ public:
 	const QStringList& inputRasterFormatListDialog() const;
 
 	/** Member functions for range iterators **/
-	NamePluginPairRangeIterator namePluginPairIterator() const;
+	PluginRangeIterator namePluginPairIterator() const;
 	FilterPluginRangeIterator filterPluginIterator() const;
 	IOMeshPluginIterator ioMeshPluginIterator() const;
 	IORasterPluginIterator ioRasterPluginIterator() const;
@@ -91,32 +91,32 @@ private:
 	QDir pluginsDir;
 
 	//all plugins (except Edit plugins)
-	std::map<QString, PluginFileInterface*> allPlugins;
+	std::vector<PluginFileInterface*> allPlugins;
 
 	//IOMeshPlugins
-	QVector<IOMeshPluginInterface*> ioMeshPlugins;
+	std::vector<IOMeshPluginInterface*> ioMeshPlugins;
 	QMap<QString,IOMeshPluginInterface*> inputMeshFormatToPluginMap;
 	QMap<QString,IOMeshPluginInterface*> outputMeshFormatToPluginMap;
 	QStringList inputMeshFormatsDialogStringList; //todo: remove this
 	QStringList outputMeshFormatsDialogStringList; //todo: remove this
 
 	//IORasterPlugins
-	QVector<IORasterPluginInterface*> ioRasterPlugins;
+	std::vector<IORasterPluginInterface*> ioRasterPlugins;
 	QMap<QString, IORasterPluginInterface*> inputRasterFormatToPluginMap;
 	QStringList inputRasterFormatsDialogStringList;
 
 	//Filter Plugins
-	QVector<FilterPluginInterface*> filterPlugins;
+	std::vector<FilterPluginInterface*> filterPlugins;
 	QMap<QString, QAction*> actionFilterMap;
 
 	//Render Plugins
-	QVector<RenderPluginInterface*> renderPlugins;
+	std::vector<RenderPluginInterface*> renderPlugins;
 
 	//Decorate Plugins
-	QVector<DecoratePluginInterface*> decoratePlugins;
+	std::vector<DecoratePluginInterface*> decoratePlugins;
 
 	//Edit Plugins
-	QVector<EditPluginInterfaceFactory*> editPlugins;
+	std::vector<EditPluginInterfaceFactory*> editPlugins;
 
 	//Private member functions
 	bool loadPlugin(const QString& filename);

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -59,9 +59,10 @@ public:
 	void loadPlugins();
 	void loadPlugins(QDir pluginsDirectory);
 	void loadPlugin(const QString& filename);
+	void unloadPlugin(PluginFileInterface* ifp);
 	
-	void enablePlugin(PluginFileInterface* fpi);
-	void disablePlugin(PluginFileInterface* fpi);
+	void enablePlugin(PluginFileInterface* ifp);
+	void disablePlugin(PluginFileInterface* ifp);
 	
 	QString pluginsCode() const;
 
@@ -130,6 +131,13 @@ private:
 	void loadDecoratePlugin(DecoratePluginInterface* iDecorate);
 	void loadRenderPlugin(RenderPluginInterface* iRender);
 	void loadEditPlugin(EditPluginInterfaceFactory* iEditFactory);
+	
+	void unloadFilterPlugin(FilterPluginInterface* iFilter);
+	void unloadIOMeshPlugin(IOMeshPluginInterface* iIOMesh);
+	void unloadIORasterPlugin(IORasterPluginInterface* iIORaster);
+	void unloadDecoratePlugin(DecoratePluginInterface* iDecorate);
+	void unloadRenderPlugin(RenderPluginInterface* iRender);
+	void unloadEditPlugin(EditPluginInterfaceFactory* iEditFactory);
 	
 	template <typename RangeIterator>
 	static QStringList inputFormatListDialog(RangeIterator iterator);

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -91,7 +91,7 @@ private:
 	QDir pluginsDir;
 
 	//all plugins (except Edit plugins)
-	std::map<QString, PluginInterface*> allPlugins;
+	std::map<QString, PluginFileInterface*> allPlugins;
 
 	//IOMeshPlugins
 	QVector<IOMeshPluginInterface*> ioMeshPlugins;

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -54,8 +54,10 @@ public:
 	class EditPluginFactoryRangeIterator;
 
 	/** Member functions **/
+	static void checkPlugin(const QString& filename);
+	
 	void loadPlugins();
-	void loadPlugins(const QDir& pluginsDirectory);
+	void loadPlugins(QDir pluginsDirectory);
 	void loadPlugin(const QString& filename);
 	
 	void enablePlugin(PluginFileInterface* fpi);
@@ -95,8 +97,6 @@ public:
 	EditPluginFactoryRangeIterator editPluginFactoryIterator(bool iterateAlsoDisabledPlugins = false) const;
 
 private:
-	QDir pluginsDir;
-
 	//all plugins (except Edit plugins)
 	std::vector<PluginFileInterface*> allPlugins;
 
@@ -121,6 +121,8 @@ private:
 
 	//Edit Plugins
 	std::vector<EditPluginInterfaceFactory*> editPlugins;
+	
+	static void checkFilterPlugin(FilterPluginInterface* iFilter);
 	
 	void loadFilterPlugin(FilterPluginInterface* iFilter);
 	void loadIOMeshPlugin(IOMeshPluginInterface* iIOMesh);

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -79,7 +79,7 @@ public:
 	const QStringList& inputRasterFormatListDialog() const;
 
 	/** Member functions for range iterators **/
-	PluginRangeIterator namePluginPairIterator() const;
+	PluginRangeIterator pluginIterator() const;
 	FilterPluginRangeIterator filterPluginIterator() const;
 	IOMeshPluginIterator ioMeshPluginIterator() const;
 	IORasterPluginIterator ioRasterPluginIterator() const;

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -58,6 +58,9 @@ public:
 	void loadPlugins(const QDir& pluginsDirectory);
 	void loadPlugin(const QString& filename);
 	
+	void enablePlugin(PluginFileInterface* fpi);
+	void disablePlugin(PluginFileInterface* fpi);
+	
 	QString pluginsCode() const;
 
 	unsigned int size() const;
@@ -125,20 +128,6 @@ private:
 	void loadDecoratePlugin(DecoratePluginInterface* iDecorate, const QString& fileName);
 	void loadRenderPlugin(RenderPluginInterface* iRender, const QString& fileName);
 	void loadEditPlugin(EditPluginInterfaceFactory* iEditFactory, const QString& fileName);
-	
-	void fillKnownIOFormats();
-
-	static QString addPluginRasterFormats(
-			QMap<QString, IORasterPluginInterface*>& map, 
-			QStringList& formatFilters, 
-			IORasterPluginInterface* pRasterIOPlugin,
-			const QList<FileFormat>& format);
-
-	static QString addPluginMeshFormats(
-			QMap<QString, IOMeshPluginInterface*>& map, 
-			QStringList& formatFilters, 
-			IOMeshPluginInterface* pMeshIOPlugin,
-			const QList<FileFormat>& format);
 };
 
 #include "plugin_manager_iterators.h"

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -77,6 +77,8 @@ public:
 	const QStringList& inputMeshFormatListDialog() const;
 	const QStringList& outputMeshFormatListDialog() const;
 	const QStringList& inputRasterFormatListDialog() const;
+	
+	PluginFileInterface* operator [](unsigned int i) const;
 
 	/** Member functions for range iterators **/
 	PluginRangeIterator pluginIterator() const;

--- a/src/common/plugins/plugin_manager.h
+++ b/src/common/plugins/plugin_manager.h
@@ -83,13 +83,13 @@ public:
 	PluginFileInterface* operator [](unsigned int i) const;
 
 	/** Member functions for range iterators **/
-	PluginRangeIterator pluginIterator() const;
-	FilterPluginRangeIterator filterPluginIterator() const;
-	IOMeshPluginIterator ioMeshPluginIterator() const;
-	IORasterPluginIterator ioRasterPluginIterator() const;
-	RenderPluginRangeIterator renderPluginIterator() const;
-	DecoratePluginRangeIterator decoratePluginIterator() const;
-	EditPluginFactoryRangeIterator editPluginFactoryIterator() const;
+	PluginRangeIterator pluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	FilterPluginRangeIterator filterPluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	IOMeshPluginIterator ioMeshPluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	IORasterPluginIterator ioRasterPluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	RenderPluginRangeIterator renderPluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	DecoratePluginRangeIterator decoratePluginIterator(bool iterateAlsoDisabledPlugins = false) const;
+	EditPluginFactoryRangeIterator editPluginFactoryIterator(bool iterateAlsoDisabledPlugins = false) const;
 
 private:
 	QDir pluginsDir;

--- a/src/common/plugins/plugin_manager_iterators.h
+++ b/src/common/plugins/plugin_manager_iterators.h
@@ -42,7 +42,10 @@ public:
 			const pointer& it, 
 			bool iterateAlsoDisabledPlugins = false) 
 		: c(c), m_ptr(it), iterateAlsoDisabledPlugins(iterateAlsoDisabledPlugins)
-	{}
+	{
+		if (m_ptr != c.end() && !iterateAlsoDisabledPlugins && !(*m_ptr)->isEnabled())
+			++(*this);
+	}
 	value_type operator*() const {return *m_ptr; } 
 	pointer operator->() { return m_ptr; }
 	ConstPluginIterator& operator++() {

--- a/src/common/plugins/plugin_manager_iterators.h
+++ b/src/common/plugins/plugin_manager_iterators.h
@@ -26,12 +26,37 @@
 
 #include "plugin_manager.h"
 
+class ConstPluginIterator 
+{
+public:
+	using Container         = std::vector<PluginFileInterface*>;
+	using iterator_category = std::forward_iterator_tag;
+	using difference_type   = std::ptrdiff_t;
+	using value_type        = PluginFileInterface*;
+	using pointer           = Container::const_iterator;  
+	using reference         = PluginFileInterface*&;
+	
+	ConstPluginIterator(const Container& c, const pointer& it) : c(c), m_ptr(it){}
+	value_type operator*() const {return *m_ptr; } 
+	pointer operator->() { return m_ptr; }
+	ConstPluginIterator& operator++() { m_ptr++; return *this; } 
+	ConstPluginIterator operator++(int) { ConstPluginIterator tmp = *this; ++(*this); return tmp; }
+	friend bool operator== (const ConstPluginIterator& a, const ConstPluginIterator& b) { return a.m_ptr == b.m_ptr; };
+	friend bool operator!= (const ConstPluginIterator& a, const ConstPluginIterator& b) { return a.m_ptr != b.m_ptr; };
+	
+private:
+	const Container& c;
+	pointer m_ptr;
+};
+
+/** Range iterators **/
+
 class PluginManager::PluginRangeIterator
 {
 	friend class PluginManager;
 public:
-	std::vector<PluginFileInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
-	std::vector<PluginFileInterface*>::const_iterator end() {return pm->allPlugins.end();}
+	ConstPluginIterator begin() {return ConstPluginIterator(pm->allPlugins, pm->allPlugins.begin());}
+	ConstPluginIterator end()   {return ConstPluginIterator(pm->allPlugins, pm->allPlugins.end());}
 private:
 	PluginRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;

--- a/src/common/plugins/plugin_manager_iterators.h
+++ b/src/common/plugins/plugin_manager_iterators.h
@@ -26,14 +26,14 @@
 
 #include "plugin_manager.h"
 
-class PluginManager::NamePluginPairRangeIterator
+class PluginManager::PluginRangeIterator
 {
 	friend class PluginManager;
 public:
-	std::map<QString, PluginFileInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
-	std::map<QString, PluginFileInterface*>::const_iterator end() {return pm->allPlugins.end();}
+	std::vector<PluginFileInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
+	std::vector<PluginFileInterface*>::const_iterator end() {return pm->allPlugins.end();}
 private:
-	NamePluginPairRangeIterator(const PluginManager* pm) : pm(pm) {}
+	PluginRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
 };
 
@@ -41,8 +41,8 @@ class PluginManager::FilterPluginRangeIterator
 {
 	friend class PluginManager;
 public:
-	QVector<FilterPluginInterface*>::const_iterator begin() {return pm->filterPlugins.begin();}
-	QVector<FilterPluginInterface*>::const_iterator end() {return pm->filterPlugins.end();}
+	std::vector<FilterPluginInterface*>::const_iterator begin() {return pm->filterPlugins.begin();}
+	std::vector<FilterPluginInterface*>::const_iterator end() {return pm->filterPlugins.end();}
 private:
 	FilterPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
@@ -52,8 +52,8 @@ class PluginManager::IOMeshPluginIterator
 {
 	friend class PluginManager;
 public:
-	QVector<IOMeshPluginInterface*>::const_iterator begin() {return pm->ioMeshPlugins.begin();}
-	QVector<IOMeshPluginInterface*>::const_iterator end() {return pm->ioMeshPlugins.end();}
+	std::vector<IOMeshPluginInterface*>::const_iterator begin() {return pm->ioMeshPlugins.begin();}
+	std::vector<IOMeshPluginInterface*>::const_iterator end() {return pm->ioMeshPlugins.end();}
 private:
 	IOMeshPluginIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
@@ -63,8 +63,8 @@ class PluginManager::IORasterPluginIterator
 {
 	friend class PluginManager;
 public:
-	QVector<IORasterPluginInterface*>::const_iterator begin() {return pm->ioRasterPlugins.begin();}
-	QVector<IORasterPluginInterface*>::const_iterator end() {return pm->ioRasterPlugins.end();}
+	std::vector<IORasterPluginInterface*>::const_iterator begin() {return pm->ioRasterPlugins.begin();}
+	std::vector<IORasterPluginInterface*>::const_iterator end() {return pm->ioRasterPlugins.end();}
 private:
 	IORasterPluginIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
@@ -74,8 +74,8 @@ class PluginManager::RenderPluginRangeIterator
 {
 	friend class PluginManager;
 public:
-	QVector<RenderPluginInterface*>::const_iterator begin() {return pm->renderPlugins.begin();}
-	QVector<RenderPluginInterface*>::const_iterator end() {return pm->renderPlugins.end();}
+	std::vector<RenderPluginInterface*>::const_iterator begin() {return pm->renderPlugins.begin();}
+	std::vector<RenderPluginInterface*>::const_iterator end() {return pm->renderPlugins.end();}
 private:
 	RenderPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
@@ -85,8 +85,8 @@ class PluginManager::DecoratePluginRangeIterator
 {
 	friend class PluginManager;
 public:
-	QVector<DecoratePluginInterface*>::const_iterator begin() {return pm->decoratePlugins.begin();}
-	QVector<DecoratePluginInterface*>::const_iterator end() {return pm->decoratePlugins.end();}
+	std::vector<DecoratePluginInterface*>::const_iterator begin() {return pm->decoratePlugins.begin();}
+	std::vector<DecoratePluginInterface*>::const_iterator end() {return pm->decoratePlugins.end();}
 private:
 	DecoratePluginRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;
@@ -96,8 +96,8 @@ class PluginManager::EditPluginFactoryRangeIterator
 {
 	friend class PluginManager;
 public:
-	QVector<EditPluginInterfaceFactory*>::const_iterator begin() {return pm->editPlugins.begin();}
-	QVector<EditPluginInterfaceFactory*>::const_iterator end() {return pm->editPlugins.end();}
+	std::vector<EditPluginInterfaceFactory*>::const_iterator begin() {return pm->editPlugins.begin();}
+	std::vector<EditPluginInterfaceFactory*>::const_iterator end() {return pm->editPlugins.end();}
 private:
 	EditPluginFactoryRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;

--- a/src/common/plugins/plugin_manager_iterators.h
+++ b/src/common/plugins/plugin_manager_iterators.h
@@ -30,8 +30,8 @@ class PluginManager::NamePluginPairRangeIterator
 {
 	friend class PluginManager;
 public:
-	std::map<QString, PluginInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
-	std::map<QString, PluginInterface*>::const_iterator end() {return pm->allPlugins.end();}
+	std::map<QString, PluginFileInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
+	std::map<QString, PluginFileInterface*>::const_iterator end() {return pm->allPlugins.end();}
 private:
 	NamePluginPairRangeIterator(const PluginManager* pm) : pm(pm) {}
 	const PluginManager* pm;

--- a/src/common/plugins/plugin_manager_iterators.h
+++ b/src/common/plugins/plugin_manager_iterators.h
@@ -1,0 +1,106 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005-2021                                           \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#ifndef MESHLAB_PLUGIN_MANAGER_ITERATORS_H
+#define MESHLAB_PLUGIN_MANAGER_ITERATORS_H
+
+#include "plugin_manager.h"
+
+class PluginManager::NamePluginPairRangeIterator
+{
+	friend class PluginManager;
+public:
+	std::map<QString, PluginInterface*>::const_iterator begin() {return pm->allPlugins.begin();}
+	std::map<QString, PluginInterface*>::const_iterator end() {return pm->allPlugins.end();}
+private:
+	NamePluginPairRangeIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::FilterPluginRangeIterator
+{
+	friend class PluginManager;
+public:
+	QVector<FilterPluginInterface*>::const_iterator begin() {return pm->filterPlugins.begin();}
+	QVector<FilterPluginInterface*>::const_iterator end() {return pm->filterPlugins.end();}
+private:
+	FilterPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::IOMeshPluginIterator
+{
+	friend class PluginManager;
+public:
+	QVector<IOMeshPluginInterface*>::const_iterator begin() {return pm->ioMeshPlugins.begin();}
+	QVector<IOMeshPluginInterface*>::const_iterator end() {return pm->ioMeshPlugins.end();}
+private:
+	IOMeshPluginIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::IORasterPluginIterator
+{
+	friend class PluginManager;
+public:
+	QVector<IORasterPluginInterface*>::const_iterator begin() {return pm->ioRasterPlugins.begin();}
+	QVector<IORasterPluginInterface*>::const_iterator end() {return pm->ioRasterPlugins.end();}
+private:
+	IORasterPluginIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::RenderPluginRangeIterator
+{
+	friend class PluginManager;
+public:
+	QVector<RenderPluginInterface*>::const_iterator begin() {return pm->renderPlugins.begin();}
+	QVector<RenderPluginInterface*>::const_iterator end() {return pm->renderPlugins.end();}
+private:
+	RenderPluginRangeIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::DecoratePluginRangeIterator
+{
+	friend class PluginManager;
+public:
+	QVector<DecoratePluginInterface*>::const_iterator begin() {return pm->decoratePlugins.begin();}
+	QVector<DecoratePluginInterface*>::const_iterator end() {return pm->decoratePlugins.end();}
+private:
+	DecoratePluginRangeIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+class PluginManager::EditPluginFactoryRangeIterator
+{
+	friend class PluginManager;
+public:
+	QVector<EditPluginInterfaceFactory*>::const_iterator begin() {return pm->editPlugins.begin();}
+	QVector<EditPluginInterfaceFactory*>::const_iterator end() {return pm->editPlugins.end();}
+private:
+	EditPluginFactoryRangeIterator(const PluginManager* pm) : pm(pm) {}
+	const PluginManager* pm;
+};
+
+#endif // MESHLAB_PLUGIN_MANAGER_ITERATORS_H

--- a/src/common/searcher.cpp
+++ b/src/common/searcher.cpp
@@ -32,6 +32,11 @@ bool WordActionsMap::getActionsPerWord( const QString& word,QList<QAction*>& res
 	return false;
 }
 
+void WordActionsMap::clear()
+{
+	wordacts.clear();
+}
+
 WordActionsMapAccessor::WordActionsMapAccessor()
 :map(),sepexp(),ignexp()
 {

--- a/src/common/searcher.h
+++ b/src/common/searcher.h
@@ -16,6 +16,7 @@ public:
 	void addWordsPerAction(QAction& act,const QStringList& words);
 	void removeActionReferences(QAction& act);
 	bool getActionsPerWord( const QString& word,QList<QAction*>& res ) const;
+	void clear();
 private:
     QMap<QString,QList<QAction*> > wordacts;
 };
@@ -33,6 +34,7 @@ public:
 	int rankedMatchesPerInputString(const QString& input,RankedMatches& rm) const;
 	inline QRegExp separtor() const {return sepexp;}
 	inline QRegExp ignored() const {return ignexp;}
+	void clear() {map.clear(); sepexp = QRegExp(); ignexp = QRegExp();}
 
 private:
 	void purifiedSplit(const QString& input,QStringList& res) const;

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -2,9 +2,6 @@
 # Copyright 2019, 2020, Visual Computing Lab, ISTI - Italian National Research Council
 # SPDX-License-Identifier: BSL-1.0
 
-# GLEW - required
-include(${EXTERNAL_DIR}/glew.cmake)
-
 if(NOT BUILD_MINI)
 	message(STATUS "Searching for optional components")
 	include(${EXTERNAL_DIR}/external.cmake)

--- a/src/external/external_common.cmake
+++ b/src/external/external_common.cmake
@@ -14,3 +14,6 @@ endif()
 
 # Eigen3 - required
 include(${EXTERNAL_DIR}/eigen.cmake)
+
+# GLEW - required
+include(${EXTERNAL_DIR}/glew.cmake)

--- a/src/general.pri
+++ b/src/general.pri
@@ -8,6 +8,12 @@
 # it can be double or float according to user needs.
 DEFINES += MESHLAB_SCALAR=float
 
+# defining meshlab version
+exists($$PWD/../ML_VERSION){
+	MESHLAB_VERSION = $$cat($$PWD/../ML_VERSION)
+	DEFINES += "MESHLAB_VERSION=$$MESHLAB_VERSION"
+}
+
 # VCG directory
 VCGDIR = $$MESHLAB_SOURCE_DIRECTORY/vcglib
 

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -98,9 +98,11 @@ void PluginInfoDialog::uninstallPluginPushButtonClicked()
 void PluginInfoDialog::on_loadPluginsPushButton_clicked()
 {
 #ifdef _WIN32
-	QString pluginFileFormat = "*.dll MeshLab Plugin (*.dll)";
-#else //other os
-	QString pluginFileFormat = "*.so MeshLab Plugin (*.so)";
+	QString pluginFileFormat = "*MeshLab Plugin (*.dll)";
+#elif __APPLE__ //other os
+	QString pluginFileFormat = "All known formats (*.so, *.dylib);;MeshLab Plugin (*.so);;MeshLab Plugin (*.dylib)";
+#else
+	QString pluginFileFormat = "*MeshLab Plugin (*.so)";
 #endif
 	QStringList fileList = QFileDialog::getOpenFileNames(this, "Load Plugins", "", pluginFileFormat);
 	PluginManager& pm = meshlab::pluginManagerInstance();

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -71,12 +71,10 @@ void PluginInfoDialog::chechBoxStateChanged(int state)
 	PluginManager& pm = meshlab::pluginManagerInstance();
 	PluginFileInterface* fpi = pm[nPlug];
 	if (state == Qt::Checked){
-		fpi->enable();
-		//std::cerr << fpi->pluginName().toStdString() << " enabled\n";
+		pm.enablePlugin(fpi);
 	}
 	else {
-		fpi->disable();
-		//std::cerr << fpi->pluginName().toStdString() << " disabled\n";
+		pm.disablePlugin(fpi);
 	}
 }
 

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -24,13 +24,10 @@
 #include "plugin_info_dialog.h"
 #include "ui_plugin_info_dialog.h"
 
-#include <QDir>
-#include <QPluginLoader>
 #include <QCheckBox>
 #include <QPushButton>
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QStandardPaths>
 
 #include <common/plugins/interfaces/filter_plugin_interface.h>
 #include <common/plugins/interfaces/iomesh_plugin_interface.h>
@@ -39,6 +36,7 @@
 #include <common/plugins/interfaces/edit_plugin_interface.h>
 #include <common/globals.h>
 #include <common/mlexception.h>
+#include <common/mlapplication.h>
 #include <common/plugins/plugin_manager.h>
 #include <common/plugins/meshlab_plugin_type.h>
 
@@ -109,16 +107,11 @@ void PluginInfoDialog::on_loadPluginsPushButton_clicked()
 	bool loadOk = false;
 	for (const QString& fileName : fileList){
 		QFileInfo finfo(fileName);
-		QDir appDir(QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).first());
-		appDir.mkpath(appDir.absolutePath());
-		
-		appDir.mkdir("MeshLabExtraPlugins");
-		appDir.cd("MeshLabExtraPlugins");
 		
 		try {
 			PluginManager::checkPlugin(fileName);
 			
-			QString newFileName = appDir.absolutePath() + "/" +finfo.fileName();
+			QString newFileName = MeshLabApplication::extraPluginsLocation() + "/" +finfo.fileName();
 			QFile::copy(fileName, newFileName);
 			
 			pm.loadPlugin(newFileName);

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -158,6 +158,7 @@ void PluginInfoDialog::addItems(const PluginFileInterface* fpi, int nPlug, const
 	pluginItem->setText(TYPE, pluginType);
 	pluginItem->setText(FILE, fpi->pluginFileInfo().fileName());
 	pluginItem->setToolTip(FILE, fpi->pluginFileInfo().absoluteFilePath());
+	pluginItem->setText(VENDOR, fpi->vendor());
 	
 	QCheckBox* cb = new QCheckBox(this);
 	cb->setProperty("np", nPlug);

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -53,62 +53,6 @@ PluginInfoDialog::~PluginInfoDialog()
 	delete ui;
 }
 
-void PluginInfoDialog::on_treeWidget_itemClicked(QTreeWidgetItem *item, int)
-{
-	QString parent;
-	QString actionName;
-	if(item==NULL) return;
-	if (item->parent()!=NULL){
-		parent=item->parent()->text(0);
-		actionName=item->text(0);
-	}
-	else parent=item->text(0);
-	QString fileName=pathDirectory+"/"+parent;
-	QDir dir(pathDirectory);
-	QPluginLoader loader(fileName);
-	qDebug("Trying to load the plugin '%s'", qUtf8Printable(fileName));
-	QObject *plugin = loader.instance();
-	if (plugin) {
-		IOMeshPluginInterface *iMeshIO = qobject_cast<IOMeshPluginInterface *>(plugin);
-		if (iMeshIO){
-			for(const FileFormat& f: iMeshIO->importFormats()){
-				QString formats;
-				for(const QString& s: f.extensions)
-					formats+="Importer_"+s+" ";
-				if (actionName==formats) ui->labelInfo->setText(f.description);
-			}
-			for(const FileFormat& f: iMeshIO->exportFormats()){
-				QString formats;
-				for(const QString& s: f.extensions)
-					formats+="Exporter_"+s+" ";
-				if (actionName==formats) ui->labelInfo->setText(f.description);
-			}
-		}
-		DecoratePluginInterface *iDecorate = qobject_cast<DecoratePluginInterface *>(plugin);
-		if (iDecorate) {
-			for(QAction *a: iDecorate->actions())
-				if (actionName==a->text())
-					ui->labelInfo->setText(iDecorate->decorationInfo(a));
-		}
-		FilterPluginInterface *iFilter = qobject_cast<FilterPluginInterface *>(plugin);
-		if (iFilter) {
-			for(QAction *a: iFilter->actions())
-				if (actionName==a->text()) 
-					ui->labelInfo->setText(iFilter->filterInfo(iFilter->ID(a)));
-		}
-//		RenderPluginInterface *iRender = qobject_cast<RenderPluginInterface *>(plugin);
-//		if (iRender){
-//		}
-		EditPluginInterfaceFactory *iEditFactory = qobject_cast<EditPluginInterfaceFactory *>(plugin);
-		if (iEditFactory) {
-			for(QAction *a: iEditFactory->actions())
-				if(iEditFactory)
-					ui->labelInfo->setText(iEditFactory->getEditToolDescription(a));
-		}
-	}
-}
-
-
 void PluginInfoDialog::populateTreeWidget()
 {
 	ui->treeWidget->header()->setResizeMode(QHeaderView::ResizeToContents);

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -89,8 +89,12 @@ void PluginInfoDialog::uninstallPluginPushButtonClicked()
 	int nPlug = pb->property("np").toInt();
 	PluginManager& pm = meshlab::pluginManagerInstance();
 	PluginFileInterface* fpi = pm[nPlug];
-	/** TODO **/
-	std::cerr << fpi->pluginName().toStdString() << " deleted!\n";
+	QFileInfo fdel = fpi->pluginFileInfo();
+	pm.unloadPlugin(fpi);
+	QFile::remove(fdel.absoluteFilePath());
+	ui->treeWidget->clear();
+	populateTreeWidget();
+	ui->treeWidget->update();
 }
 
 void PluginInfoDialog::on_loadPluginsPushButton_clicked()
@@ -116,8 +120,6 @@ void PluginInfoDialog::on_loadPluginsPushButton_clicked()
 			
 			QString newFileName = appDir.absolutePath() + "/" +finfo.fileName();
 			QFile::copy(fileName, newFileName);
-			
-			std::cerr << "PATH: " << newFileName.toStdString() << "\n";
 			
 			pm.loadPlugin(newFileName);
 			loadOk = true;

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -114,6 +114,11 @@ void PluginInfoDialog::on_loadPluginsPushButton_clicked()
 			PluginManager::checkPlugin(fileName);
 			
 			QString newFileName = MeshLabApplication::extraPluginsLocation() + "/" +finfo.fileName();
+			
+			if (QFile::exists(newFileName)){
+				throw MLException("A plugin called " + finfo.fileName() + " already exists. Please uninstall it before installing a new one.");
+			}
+			
 			QFile::copy(fileName, newFileName);
 			
 			pm.loadPlugin(newFileName);

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -100,7 +100,7 @@ void PluginInfoDialog::on_loadPluginsPushButton_clicked()
 #ifdef _WIN32
 	QString pluginFileFormat = "*MeshLab Plugin (*.dll)";
 #elif __APPLE__ //other os
-	QString pluginFileFormat = "All known formats (*.so, *.dylib);;MeshLab Plugin (*.so);;MeshLab Plugin (*.dylib)";
+	QString pluginFileFormat = "All known formats (*.so *.dylib);;MeshLab Plugin (*.so);;MeshLab Plugin (*.dylib)";
 #else
 	QString pluginFileFormat = "*MeshLab Plugin (*.so)";
 #endif

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -127,7 +127,7 @@ void PluginInfoDialog::populateTreeWidget()
 	}
 	else {
 		int nPlug = 0;
-		for (PluginFileInterface* fp : pm.pluginIterator()){
+		for (PluginFileInterface* fp : pm.pluginIterator(true)){
 			MeshLabPluginType type(fp);
 			QString pluginType = type.pluginTypeString();
 			QStringList tmplist;

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -27,6 +27,7 @@
 #include <QDir>
 #include <QPluginLoader>
 #include <QCheckBox>
+#include <QPushButton>
 
 #include <common/plugins/interfaces/filter_plugin_interface.h>
 #include <common/plugins/interfaces/iomesh_plugin_interface.h>
@@ -74,6 +75,11 @@ void PluginInfoDialog::chechBoxStateChanged(int state)
 		fpi->disable();
 		//std::cerr << fpi->pluginName().toStdString() << " disabled\n";
 	}
+}
+
+void PluginInfoDialog::on_loadPluginsPushButton_clicked()
+{
+	
 }
 
 void PluginInfoDialog::populateTreeWidget()
@@ -158,7 +164,14 @@ void PluginInfoDialog::addItems(const PluginFileInterface* fpi, int nPlug, const
 	cb->setChecked(fpi->isEnabled());
 	connect(cb, SIGNAL(stateChanged(int)),
 			this, SLOT(chechBoxStateChanged(int)));
-	ui->treeWidget->setItemWidget(pluginItem, LOAD, cb);
+	ui->treeWidget->setItemWidget(pluginItem, ENABLED, cb);
+	
+	QPushButton* pb = new QPushButton(this);
+	pb->setProperty("np", nPlug);
+	pb->setIcon(uninstallIcon);
+	if (fpi->pluginFileInfo().absolutePath() == meshlab::defaultPluginPath())
+		pb->setEnabled(false);
+	ui->treeWidget->setItemWidget(pluginItem, UNINSTALL, pb);
 	
 	//pluginItem->setIcon(UNINSTALL, uninstallIcon);
 	ui->treeWidget->setItemExpanded(pluginItem, false);
@@ -171,4 +184,3 @@ void PluginInfoDialog::addItems(const PluginFileInterface* fpi, int nPlug, const
 		featureItem->setIcon(PLUGINS, featureIcon);
 	}
 }
-

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -44,6 +44,7 @@ PluginInfoDialog::PluginInfoDialog(QWidget *parent) :
 	interfaceIcon.addPixmap(style()->standardPixmap(QStyle::SP_DirOpenIcon),QIcon::Normal, QIcon::On);
 	interfaceIcon.addPixmap(style()->standardPixmap(QStyle::SP_DirClosedIcon),QIcon::Normal, QIcon::Off);
 	featureIcon.addPixmap(style()->standardPixmap(QStyle::SP_FileIcon));
+	uninstallIcon.addPixmap(style()->standardPixmap(QStyle::SP_DialogCancelButton));
 	
 	populateTreeWidget();
 }
@@ -57,7 +58,7 @@ void PluginInfoDialog::populateTreeWidget()
 {
 	ui->treeWidget->header()->setResizeMode(QHeaderView::ResizeToContents);
 	ui->treeWidget->header()->setStretchLastSection(false);
-	ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+	ui->treeWidget->header()->setSectionResizeMode(PLUGINS, QHeaderView::Stretch);
 	PluginManager& pm = meshlab::pluginManagerInstance();
 	if (pm.size() == 0){
 		ui->label->setText(tr("No plugin has been loaded."));
@@ -136,17 +137,18 @@ void PluginInfoDialog::populateTreeWidget()
 void PluginInfoDialog::addItems(const QString& pluginName, const QString& pluginType, const QStringList& features)
 {
 	QTreeWidgetItem *pluginItem = new QTreeWidgetItem(ui->treeWidget);
-	pluginItem->setText(0, pluginName);
-	pluginItem->setIcon(0, interfaceIcon);
-	pluginItem->setText(1, pluginType);
+	pluginItem->setText(PLUGINS, pluginName);
+	pluginItem->setIcon(PLUGINS, interfaceIcon);
+	pluginItem->setText(TYPE, pluginType);
+	//pluginItem->setIcon(UNINSTALL, uninstallIcon);
 	ui->treeWidget->setItemExpanded(pluginItem, false);
-	QFont boldFont = pluginItem->font(0);
+	QFont boldFont = pluginItem->font(PLUGINS);
 	boldFont.setBold(true);
-	pluginItem->setFont(0, boldFont);
+	pluginItem->setFont(PLUGINS, boldFont);
 	for (const QString& feature: features) {
 		QTreeWidgetItem *featureItem = new QTreeWidgetItem(pluginItem);
-		featureItem->setText(0, feature);
-		featureItem->setIcon(0, featureIcon);
+		featureItem->setText(PLUGINS, feature);
+		featureItem->setIcon(PLUGINS, featureIcon);
 	}
 }
 

--- a/src/meshlab/dialogs/plugin_info_dialog.cpp
+++ b/src/meshlab/dialogs/plugin_info_dialog.cpp
@@ -34,6 +34,7 @@
 #include <common/plugins/interfaces/edit_plugin_interface.h>
 #include <common/globals.h>
 #include <common/plugins/plugin_manager.h>
+#include <common/plugins/meshlab_plugin_type.h>
 
 PluginInfoDialog::PluginInfoDialog(QWidget *parent) :
 	QDialog(parent),
@@ -65,68 +66,55 @@ void PluginInfoDialog::populateTreeWidget()
 		ui->treeWidget->hide();
 	}
 	else {
-		QString pluginType;
-		
-		pluginType = "Decorate";
-		for (DecoratePluginInterface* dpi : pm.decoratePluginIterator()){
+		for (PluginFileInterface* fp : pm.pluginIterator()){
+			MeshLabPluginType type(fp);
+			QString pluginType = type.pluginTypeString();
 			QStringList tmplist;
-			for(QAction *a: dpi->actions())
-				tmplist.push_back(a->text());
-			addItems(dpi->pluginName(), pluginType, tmplist);
-		}
-		
-		pluginType = "Edit";
-		for (EditPluginInterfaceFactory* epi : pm.editPluginFactoryIterator()){
-			QStringList tmplist;
-			for(QAction *a: epi->actions())
-				tmplist.push_back(a->text());
-			addItems(epi->pluginName(), pluginType, tmplist);
-		}
-		
-		pluginType = "Filter";
-		for (FilterPluginInterface* fpi : pm.filterPluginIterator()){
-			QStringList tmplist;
-			for(QAction *a: fpi->actions())
-				tmplist.push_back(a->text());
-			addItems(fpi->pluginName(), pluginType, tmplist);
-		}
-		
-		pluginType = "IOMesh";
-		for (IOMeshPluginInterface* iopi : pm.ioMeshPluginIterator()){
-			QStringList tmplist;
-			for(const FileFormat& f: iopi->importFormats()){
-				QString formats;
-				for(const QString& s : f.extensions)
-					formats+="Importer_"+s+" ";
-				tmplist.push_back(formats);
+			if (type.isDecoratePlugin()){
+				DecoratePluginInterface* dpi = dynamic_cast<DecoratePluginInterface*>(fp);
+				for(QAction *a: dpi->actions())
+					tmplist.push_back(a->text());
 			}
-			for(const FileFormat& f: iopi->exportFormats()){
-				QString formats;
-				for(const QString& s: f.extensions)
-					formats+="Exporter_"+s+" ";
-				tmplist.push_back(formats);
+			if (type.isEditPlugin()){
+				EditPluginInterfaceFactory* epi = dynamic_cast<EditPluginInterfaceFactory*>(fp);
+				for(QAction *a: epi->actions())
+					tmplist.push_back(a->text());
 			}
-			addItems(iopi->pluginName(), pluginType, tmplist);
-		}
-		
-		pluginType = "IORaster";
-		for (IORasterPluginInterface* iorpi: pm.ioRasterPluginIterator()){
-			QStringList tmplist;
-			for(const FileFormat& f: iorpi->importFormats()){
-				QString formats;
-				for(const QString& s : f.extensions)
-					formats+="Importer_"+s+" ";
-				tmplist.push_back(formats);
+			if (type.isFilterPlugin()){
+				FilterPluginInterface* fpi = dynamic_cast<FilterPluginInterface*>(fp);
+				for(QAction *a: fpi->actions())
+					tmplist.push_back(a->text());
 			}
-			addItems(iorpi->pluginName(), pluginType, tmplist);
-		}
-		
-		pluginType = "Render";
-		for (RenderPluginInterface* rpi : pm.renderPluginIterator()){
-			QStringList tmplist;
-			for(QAction *a: rpi->actions())
-				tmplist.push_back(a->text());
-			addItems(rpi->pluginName(), pluginType, tmplist);
+			if (type.isIOMeshPlugin()){
+				IOMeshPluginInterface* iopi = dynamic_cast<IOMeshPluginInterface*>(fp);
+				for(const FileFormat& f: iopi->importFormats()){
+					QString formats;
+					for(const QString& s : f.extensions)
+						formats+="Importer_"+s+" ";
+					tmplist.push_back(formats);
+				}
+				for(const FileFormat& f: iopi->exportFormats()){
+					QString formats;
+					for(const QString& s: f.extensions)
+						formats+="Exporter_"+s+" ";
+					tmplist.push_back(formats);
+				}
+			}
+			if (type.isIORasterPlugin()){
+				IORasterPluginInterface* iorpi = dynamic_cast<IORasterPluginInterface*>(fp);
+				for(const FileFormat& f: iorpi->importFormats()){
+					QString formats;
+					for(const QString& s : f.extensions)
+						formats+="Importer_"+s+" ";
+					tmplist.push_back(formats);
+				}
+			}
+			if (type.isRenderPlugin()){
+				RenderPluginInterface* rpi = dynamic_cast<RenderPluginInterface*>(fp);
+				for(QAction *a: rpi->actions())
+					tmplist.push_back(a->text());
+			}
+			addItems(fp->pluginName(), pluginType, tmplist);
 		}
 		
 		std::string lbl = "Number of plugin loaded: " + std::to_string(pm.size());

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -41,13 +41,10 @@ public:
 	explicit PluginInfoDialog(QWidget *parent = nullptr);
 	~PluginInfoDialog();
 
-private slots:
-	void on_treeWidget_itemClicked(QTreeWidgetItem *item, int column);
-	
 private:
 	void populateTreeWidget();
 	void addItems(const QString& pluginName, const QString& pluginType, const QStringList &features);
-	
+
 	Ui::PluginInfoDialog *ui;
 	QIcon interfaceIcon;
 	QIcon featureIcon;

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -32,6 +32,7 @@ class PluginInfoDialog;
 }
 
 class QTreeWidgetItem;
+class PluginFileInterface;
 
 class PluginInfoDialog : public QDialog
 {
@@ -40,12 +41,15 @@ class PluginInfoDialog : public QDialog
 public:
 	explicit PluginInfoDialog(QWidget *parent = nullptr);
 	~PluginInfoDialog();
+	
+private slots:
+	void chechBoxStateChanged(int state);
 
 private:
 	enum PluginDialogColumn{PLUGINS = 0, LOAD, TYPE, VENDOR, FILE, UNINSTALL};
 	
 	void populateTreeWidget();
-	void addItems(const QString& pluginName, const QString& pluginType, const QStringList &features);
+	void addItems(const PluginFileInterface* fpi, int nPlug, const QString& pluginType, const QStringList &features);
 
 	Ui::PluginInfoDialog *ui;
 	QIcon interfaceIcon;

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -42,12 +42,15 @@ public:
 	~PluginInfoDialog();
 
 private:
+	enum PluginDialogColumn{PLUGINS = 0, LOAD, TYPE, VENDOR, FILE, UNINSTALL};
+	
 	void populateTreeWidget();
 	void addItems(const QString& pluginName, const QString& pluginType, const QStringList &features);
 
 	Ui::PluginInfoDialog *ui;
 	QIcon interfaceIcon;
 	QIcon featureIcon;
+	QIcon uninstallIcon;
 	QString pathDirectory;
 };
 

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -46,7 +46,7 @@ private slots:
 	void chechBoxStateChanged(int state);
 
 private:
-	enum PluginDialogColumn{PLUGINS = 0, LOAD, TYPE, VENDOR, FILE, UNINSTALL};
+	enum PluginDialogColumn{PLUGINS = 0, ENABLED, TYPE, VENDOR, FILE, UNINSTALL};
 	
 	void populateTreeWidget();
 	void addItems(const PluginFileInterface* fpi, int nPlug, const QString& pluginType, const QStringList &features);

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -44,6 +44,7 @@ public:
 	
 private slots:
 	void chechBoxStateChanged(int state);
+	void uninstallPluginPushButtonClicked();
 
 	void on_loadPluginsPushButton_clicked();
 	

--- a/src/meshlab/dialogs/plugin_info_dialog.h
+++ b/src/meshlab/dialogs/plugin_info_dialog.h
@@ -45,6 +45,8 @@ public:
 private slots:
 	void chechBoxStateChanged(int state);
 
+	void on_loadPluginsPushButton_clicked();
+	
 private:
 	enum PluginDialogColumn{PLUGINS = 0, ENABLED, TYPE, VENDOR, FILE, UNINSTALL};
 	

--- a/src/meshlab/dialogs/plugin_info_dialog.ui
+++ b/src/meshlab/dialogs/plugin_info_dialog.ui
@@ -46,7 +46,27 @@
      </column>
      <column>
       <property name="text">
+       <string>Load</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
        <string>Type</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Vendor</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>File</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Uninstall</string>
       </property>
      </column>
     </widget>

--- a/src/meshlab/dialogs/plugin_info_dialog.ui
+++ b/src/meshlab/dialogs/plugin_info_dialog.ui
@@ -46,7 +46,7 @@
      </column>
      <column>
       <property name="text">
-       <string>Load</string>
+       <string>Enabled</string>
       </property>
      </column>
      <column>

--- a/src/meshlab/dialogs/plugin_info_dialog.ui
+++ b/src/meshlab/dialogs/plugin_info_dialog.ui
@@ -14,24 +14,17 @@
    <string>Plugin Information</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
+   <item row="2" column="0">
+    <widget class="QPushButton" name="loadPluginsPushButton">
      <property name="text">
-      <string>Number of plugin loaded: </string>
+      <string>Load Plugins</string>
+     </property>
+     <property name="icon">
+      <iconset theme="folder-open"/>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
     <widget class="QTreeWidget" name="treeWidget">
      <attribute name="headerCascadingSectionResizes">
       <bool>false</bool>
@@ -71,30 +64,21 @@
      </column>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Info plugin</string>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Number of plugin loaded: </string>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="labelInfo">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -258,6 +258,7 @@ private:
 	void fillDecorateMenu();
 	void fillRenderMenu();
 	void fillEditMenu();
+	void updateAllPluginsActions();
 	void createToolBars();
 	void loadMeshLabSettings();
 	void keyPressEvent(QKeyEvent *);

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -70,7 +70,15 @@ MainWindow::MainWindow():
 	catch (const MLException& e) {
 		QMessageBox::warning(this, "Error while loading plugins.", e.what());
 	}
-
+	QSettings settings;
+	
+	//disable previously disabled plugins
+	QStringList disabledPlugins = settings.value("DisabledPlugins").value<QStringList>();
+	for (PluginFileInterface* fp : PM.pluginIterator(true)){
+		if (disabledPlugins.contains(fp->pluginName()))
+			PM.disablePlugin(fp);
+	}
+	
 
 	//setCentralWidget(workspace);
 	setCentralWidget(mdiarea);
@@ -85,7 +93,7 @@ MainWindow::MainWindow():
 	QIcon icon;
 	icon.addPixmap(QPixmap(":images/eye48.png"));
 	setWindowIcon(icon);
-	QSettings settings;
+	
 	QVariant vers = settings.value(MeshLabApplication::versionRegisterKeyName());
 	//should update those values only after I run MeshLab for the very first time or after I installed a new version
 	if (!vers.isValid() || vers.toString() < MeshLabApplication::appVer())
@@ -879,6 +887,7 @@ void MainWindow::updateAllPluginsActions()
 	editToolBar->clear();
 	editToolBar->addAction(suspendEditModeAct);
 	for(EditPluginInterfaceFactory *iEditFactory: PM.editPluginFactoryIterator()) {
+		std::cerr << "Plugin visited: " << iEditFactory->pluginName().toStdString() << "\n";
 		for(QAction* editAction: iEditFactory->actions()){
 			if (!editAction->icon().isNull()) {
 				editToolBar->addAction(editAction);
@@ -891,6 +900,8 @@ void MainWindow::updateAllPluginsActions()
 	filterToolBar->clear();
 	updateFilterToolBar();
 	
+	//TODO update the searcher: this seems to be an impossible task due to unreadable code.
+	//for now, just close and reopen meshlab....
 	/*
 	disconnect(searchShortCut, SIGNAL(activated()), searchButton, SLOT(openMenu()));
 	wama.clear();

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -65,6 +65,7 @@ MainWindow::MainWindow():
 	addDockWidget(Qt::RightDockWidgetArea, layerDialog);
 	try {
 		PM.loadPlugins();
+		PM.loadPlugins(QDir(MeshLabApplication::extraPluginsLocation()));
 	}
 	catch (const MLException& e) {
 		QMessageBox::warning(this, "Error while loading plugins.", e.what());

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -650,8 +650,7 @@ void MainWindow::initMenuForSearching(QMenu* menu)
 	if (menu == NULL)
 		return;
 	const QList<QAction*>& acts = menu->actions();
-	foreach(QAction* act, acts)
-	{
+	for(QAction* act: acts) {
 		QMenu* submenu = act->menu();
 		if (!act->isSeparator() && (submenu == NULL))
 			initItemForSearching(act);
@@ -857,6 +856,26 @@ void MainWindow::fillEditMenu()
 			connect(editAction, SIGNAL(triggered()), this, SLOT(applyEditMode()));
 		}
 	}
+}
+
+void MainWindow::updateAllPluginsActions()
+{
+	fillFilterMenu();
+	fillDecorateMenu();
+	fillRenderMenu();
+	fillEditMenu();
+	
+	/*
+	disconnect(searchShortCut, SIGNAL(activated()), searchButton, SLOT(openMenu()));
+	wama.clear();
+	delete searchMenu;
+	
+	initSearchEngine();
+	int longest = longestActionWidthInAllMenus();
+	searchMenu = new SearchMenu(wama, 15, searchButton, longest);
+	searchButton->setMenu(searchMenu);
+	connect(searchShortCut, SIGNAL(activated()), searchButton, SLOT(openMenu()));
+	*/
 }
 
 
@@ -1193,7 +1212,7 @@ int MainWindow::longestActionWidthInAllMenus()
 {
 	int longest = 0;
 	QList<QMenu*> list = menuBar()->findChildren<QMenu*>();
-	foreach(QMenu* m, list)
+	for(QMenu* m: list)
 		longest = std::max(longest, longestActionWidthInMenu(m));
 	return longest;
 }

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -887,7 +887,6 @@ void MainWindow::updateAllPluginsActions()
 	editToolBar->clear();
 	editToolBar->addAction(suspendEditModeAct);
 	for(EditPluginInterfaceFactory *iEditFactory: PM.editPluginFactoryIterator()) {
-		std::cerr << "Plugin visited: " << iEditFactory->pluginName().toStdString() << "\n";
 		for(QAction* editAction: iEditFactory->actions()){
 			if (!editAction->icon().isNull()) {
 				editToolBar->addAction(editAction);

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -861,10 +861,35 @@ void MainWindow::fillEditMenu()
 
 void MainWindow::updateAllPluginsActions()
 {
+	//update menus
 	fillFilterMenu();
 	fillDecorateMenu();
 	fillRenderMenu();
 	fillEditMenu();
+	
+	//update toolbars
+	decoratorToolBar->clear();
+	for(DecoratePluginInterface *iDecorate: PM.decoratePluginIterator()) {
+		for(QAction *decorateAction: iDecorate->actions()) {
+			if (!decorateAction->icon().isNull())
+				decoratorToolBar->addAction(decorateAction);
+		}
+	}
+	
+	editToolBar->clear();
+	editToolBar->addAction(suspendEditModeAct);
+	for(EditPluginInterfaceFactory *iEditFactory: PM.editPluginFactoryIterator()) {
+		for(QAction* editAction: iEditFactory->actions()){
+			if (!editAction->icon().isNull()) {
+				editToolBar->addAction(editAction);
+			}
+			else qDebug() << "action was null";
+		}
+	}
+	editToolBar->addSeparator();
+	
+	filterToolBar->clear();
+	updateFilterToolBar();
 	
 	/*
 	disconnect(searchShortCut, SIGNAL(activated()), searchButton, SLOT(openMenu()));

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -63,7 +63,12 @@ MainWindow::MainWindow():
 	layerDialog->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
 	layerDialog->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
 	addDockWidget(Qt::RightDockWidgetArea, layerDialog);
-	PM.loadPlugins();
+	try {
+		PM.loadPlugins();
+	}
+	catch (const MLException& e) {
+		QMessageBox::warning(this, "Error while loading plugins.", e.what());
+	}
 
 
 	//setCentralWidget(workspace);

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -2636,6 +2636,14 @@ void MainWindow::aboutPlugins()
 	PluginInfoDialog dialog(this);
 	dialog.exec();
 	updateAllPluginsActions();
+	QSettings settings;
+	QStringList disabledPlugins;
+	for (PluginFileInterface* pf : PM.pluginIterator(true)){
+		if (!pf->isEnabled()){
+			disabledPlugins.append(pf->pluginName());
+		}
+	}
+	settings.setValue("DisabledPlugins", QVariant::fromValue(disabledPlugins));
 }
 
 void MainWindow::helpOnscreen()

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -2635,6 +2635,7 @@ void MainWindow::aboutPlugins()
 	qDebug( "aboutPlugins(): Current Plugins Dir: %s ", qUtf8Printable(meshlab::defaultPluginPath()));
 	PluginInfoDialog dialog(this);
 	dialog.exec();
+	updateAllPluginsActions();
 }
 
 void MainWindow::helpOnscreen()

--- a/src/meshlabplugins/decorate_background/decorate_background.cpp
+++ b/src/meshlabplugins/decorate_background/decorate_background.cpp
@@ -58,7 +58,7 @@ QString DecorateBackgroundPlugin::decorationInfo(FilterIDType id) const
 
 QString DecorateBackgroundPlugin::pluginName() const
 {
-    return "DecorateBackGround";
+	return "DecorateBackGround";
 }
 
 void DecorateBackgroundPlugin::initGlobalParameterList(const QAction* action, RichParameterList &parset)

--- a/src/meshlabplugins/filter_globalregistration/globalregistration.cpp
+++ b/src/meshlabplugins/filter_globalregistration/globalregistration.cpp
@@ -40,7 +40,12 @@ GlobalRegistrationPlugin::GlobalRegistrationPlugin()
 
 QString GlobalRegistrationPlugin::pluginName() const
 {
-    return "FilterGlobalRegistration";
+	return "FilterGlobalRegistration";
+}
+
+QString GlobalRegistrationPlugin::vendor() const
+{
+	return "STORM - IRIT";
 }
 
 QString GlobalRegistrationPlugin::filterName(FilterIDType filterId) const

--- a/src/meshlabplugins/filter_globalregistration/globalregistration.h
+++ b/src/meshlabplugins/filter_globalregistration/globalregistration.h
@@ -38,6 +38,7 @@ public:
     GlobalRegistrationPlugin();
 
     QString pluginName() const;
+    virtual QString vendor() const;
 
     QString filterName(FilterIDType filter) const;
     QString filterInfo(FilterIDType filter) const;

--- a/src/meshlabplugins/filter_select/meshselect.cpp
+++ b/src/meshlabplugins/filter_select/meshselect.cpp
@@ -120,7 +120,7 @@ SelectionFilterPlugin::SelectionFilterPlugin()
 
 QString SelectionFilterPlugin::pluginName() const
 {
-    return "FlterSelect";
+    return "FilterSelect";
 }
 
  QString SelectionFilterPlugin::filterName(FilterIDType filter) const


### PR DESCRIPTION
- robust plugin management;
  - each plugin file inherits from a new Plugin class, allowing to check if the loaded file is a meshlab plugin;
  - possibility to check if a plugin has been built with the same version of meshlab, and with double precision;
  - huge PluginManager refactoring;
- revised plugin info dialog with the possibility to install/uninstall or enable/disable plugins
- MeshLab ui updates when plugins status changes;