### PR TITLE
Fix order of the parameters (Re-Compute Vertex Normals)

### DIFF
--- a/src/meshlabplugins/filter_unsharp/filter_unsharp.cpp
+++ b/src/meshlabplugins/filter_unsharp/filter_unsharp.cpp
@@ -315,7 +315,7 @@ void FilterUnsharp::initParameterList(const QAction *action, MeshDocument &md, R
     switch(ID(action))
     {
         case FP_RECOMPUTE_VERTEX_NORMAL :
-            parlst.addParam(RichEnum("weightMode", 0, QStringList() << "Simple Average" <<  "By Angle" << "By Area" << "As defined by N. Max",  tr("Weighting Mode:"), ""));
+            parlst.addParam(RichEnum("weightMode", 0, QStringList() << "Simple Average" <<  "By Area" << "By Angle" << "As defined by N. Max",  tr("Weighting Mode:"), ""));
           break;
         case FP_CREASE_CUT :
             parlst.addParam(RichFloat("angleDeg", 90.f, tr("Crease Angle (degree)"), tr("If the angle between the normals of two adjacent faces is <b>larger</b> that this threshold the edge is considered a creased and the mesh is cut along it.")));


### PR DESCRIPTION
Currently order of the options is :

![image](https://user-images.githubusercontent.com/11532321/114144173-011c5700-9950-11eb-9560-88597d770c2e.png)

However, the order seems different with the manual describing(second and third),

https://github.com/cnr-isti-vclab/meshlab/blob/f2c399ac8bff483ab661227c38dd09c82cff4d77/src/meshlabplugins/filter_unsharp/filter_unsharp.cpp#L148-L152

Maybe [PyMeshLab](https://pymeshlab.readthedocs.io/en/latest/filter_list.html#re_compute_vertex_normals) should be concerned too.