### PR TITLE
[libE57Format] Port upstream fix for gcc:11

### DIFF
--- a/src/external/e57/src/E57XmlParser.cpp
+++ b/src/external/e57/src/E57XmlParser.cpp
@@ -42,6 +42,10 @@
 #include "StringNodeImpl.h"
 #include "VectorNodeImpl.h"
 
+#if __GNUC__ >= 11
+	#include <limits>
+#endif
+
 using namespace e57;
 using namespace XERCES_CPP_NAMESPACE;
 


### PR DESCRIPTION
https://github.com/asmaloney/libE57Format/commit/13f6a16394ce3eb50ea4cd21f31f77f53294e8d0