### PR TITLE
Fix shell script error in scripts/Linux/0_setup_env_ubuntu.sh

### DIFF
--- a/scripts/Linux/0_setup_env_ubuntu.sh
+++ b/scripts/Linux/0_setup_env_ubuntu.sh
@@ -7,4 +7,4 @@
 sudo apt-get update
 sudo apt-get install -y qt5-default qttools5-dev-tools qtdeclarative5-dev
 sudo apt-get install -y mesa-common-dev libglu1-mesa-dev
-sudo apt-get install -y libgmp-devlibcgal-dev libboost-all-dev patchelf cmake
+sudo apt-get install -y libgmp-dev libcgal-dev libboost-all-dev patchelf cmake


### PR DESCRIPTION
The white space may be deleted mistakenly according to [diff-3327cebb-aea3e1ef](https://github.com/cnr-isti-vclab/meshlab/commit/3327cebb9bfa57584f62daff9f2ed2ed1da6e539?branch=3327cebb9bfa57584f62daff9f2ed2ed1da6e539&diff=unified), and this error is hard to be found because `scripts/Linux/0_setup_env_ubuntu.sh` is not used in `.github/workflows/Linux.yml`.
