### PR TITLE
Fix scope of CMake Policy variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ option(MESHLAB_IS_NIGHTLY_VERSION "Nightly version of meshlab will be used inste
 
 ### Dependencies
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/meshlab_global_settings.cmake")
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/meshlab_global_settings.cmake" NO_POLICY_SCOPE)
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/meshlab_tools.cmake")
 
 #message(STATUS "Searching for required components")

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright 2019, 2020, Visual Computing Lab, ISTI - Italian National Research Council
 # SPDX-License-Identifier: BSL-1.0
 
-cmake_minimum_required(VERSION 3.10)
-
 option(
 	ALLOW_OPTIONAL_EXTERNAL_MESHLAB_LIBRARIES
 	"Allow to use/build optional external libraries"


### PR DESCRIPTION
Commit 7d47760d37b4 ("moving some settings to an apposite cmake file")
moved the `cmake_policy(SET CMP0072 NEW)` from the toplevel scope to the
scope of the included file. For details, see
https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html

Set NO_POLICY_SCOPE when including the file, to move the POLICIES back
to the toplevel scope.

Fixes #1095.