### PR TITLE
WIP: Add support for Wayland

### DIFF
--- a/src/common/GLExtensionsManager.cpp
+++ b/src/common/GLExtensionsManager.cpp
@@ -36,19 +36,19 @@ void GLExtensionsManager::init()
  */
 bool GLExtensionsManager::initializeGLextensions_notThrowing()
 {
-    GLenum err = GLEW_OK;
     if (!glewInitialized) {
         glewExperimental = GL_TRUE;
-        err = glewInit();
-        if (err != GLEW_OK) {
+        GLenum err = glewInit();
+        if ((err == GLEW_OK) ||
+            (err == GLEW_ERROR_NO_GLX_DISPLAY)) {
+            glewInitialized = true;
+        }
+        else {
             qWarning("GLEW initialization failed: %s",
                      (const char *)glewGetErrorString(err));
         }
-        else {
-            glewInitialized = true;
-        }
     }
-    return err == GLEW_OK;
+    return glewInitialized;
 
 }
 
@@ -61,12 +61,13 @@ void GLExtensionsManager::initializeGLextensions()
     if (!glewInitialized) {
         glewExperimental = GL_TRUE;
         GLenum err = glewInit();
-        if (err != GLEW_OK) {
-            throw MLException(QString("GLEW initialization failed: %1\n")
-                                  .arg((const char *)glewGetErrorString(err)));
+        if ((err == GLEW_OK) ||
+            (err == GLEW_ERROR_NO_GLX_DISPLAY)) {
+            glewInitialized = true;
         }
         else {
-            glewInitialized = true;
+            throw MLException(QString("GLEW initialization failed: %1\n")
+                                  .arg((const char *)glewGetErrorString(err)));
         }
     }
 }


### PR DESCRIPTION
This fixes the "crash" when running Meshlab under Wayland.

The "Unknown error" is actually GLEW_ERROR_NO_GLX_DISPLAY, the lookup was missing until recently:
https://github.com/nigels-com/glew/commit/ea2076658a5bdcc300ac8fde025a296b6a7a7817

As `glewContextInit` is not yet in any released GLEW version, keep using `glewInit` but ignore GLEW_ERROR_NO_GLX_DISPLAY. See https://github.com/nigels-com/glew/issues/172

While the first patch allow starting Meshlab, the central `GLArea` is not rendering correctly (i.e stays blank). Probably the FBO is not blitted correctly to the Wayland surface, investigation ongoing.

Also see #738 and #936