### PR TITLE
When splitting a view, remember the orientation

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -438,6 +438,14 @@ void MainWindow::setSplit(QAction *qa)
 	if(mvc)
 	{
 		GLArea *glwClone=new GLArea(this, mvc, &currentGlobalParams);
+
+		// Start the new view with the same orientation as the existing one
+		GLArea* glArea = mvc->currentView();
+		if(glArea) {
+			QPair<Shotm,float> shotAndScale = glArea->shotFromTrackball();
+			glwClone->loadShot(shotAndScale);
+		}
+		
 		//connect(glwClone, SIGNAL(insertRenderingDataForNewlyGeneratedMesh(int)), this, SLOT(addRenderingDataIfNewlyGeneratedMesh(int)));
 		if(qa->text() == tr("&Horizontally"))
 			mvc->addView(glwClone,Qt::Vertical);
@@ -454,7 +462,6 @@ void MainWindow::setSplit(QAction *qa)
 		
 		updateMenus();
 		
-		glwClone->resetTrackBall();
 		glwClone->update();
 	}
 	


### PR DESCRIPTION
When a Meshlab view is split, the second view resets to the default orientation, as seen here. 

![image](https://user-images.githubusercontent.com/1325676/138208589-976bc8c8-f0b6-453a-8e84-19cd971ebbdd.png)


More, after the viewers are linked, the first view switches to default orientation too. If you are focused on some inspection of a big mesh, then your orientation is lost. This change makes the second view start in the same orientation as the first one. 

This was tested very carefully. 
