### PR TITLE
Add the ability to customize the Meshlab window width and height

### DIFF
--- a/src/meshlab/main.cpp
+++ b/src/meshlab/main.cpp
@@ -83,8 +83,17 @@ int main(int argc, char *argv[])
 		handleCriticalError(exc);
 		return -1;
 	}
-	window->showMaximized();
 
+	// The Meshlab window dimensions. The default is to start maximized.
+	int width = window->mwsettings.startupWindowWidth;
+	int height = window->mwsettings.startupWindowHeight;
+	if (width > 0 && height > 0) {
+		window->resize(width, height);
+		window->show();
+	} else {
+		window->showMaximized();
+	}
+	
 	// This event filter is installed to intercept the open events sent directly by the Operative System.
 	FileOpenEater *filterObj=new FileOpenEater(window.get());
 	app.installEventFilter(filterObj);

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -86,6 +86,12 @@ public:
 
 	std::ptrdiff_t maxTextureMemory;
 	inline static QString maxTextureMemoryParam()  {return "MeshLab::System::maxTextureMemory";}
+	  
+	int startupWindowWidth;
+	inline static QString startupWindowWidthParam() {return "MeshLab::System::startupWindowWidth";}
+  
+	int startupWindowHeight;
+	inline static QString startupWindowHeightParam() {return "MeshLab::System::startupWindowHeight";}
 };
 
 class MainWindow : public QMainWindow

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -1330,6 +1330,9 @@ void MainWindowSetting::initGlobalParameterList(RichParameterList& gbllist)
 	if (MeshLabScalarTest<Scalarm>::doublePrecision())
 		gbllist.addParam(RichBool(highPrecisionRendering(), false, "High Precision Rendering", "If true all the models in the scene will be rendered at the center of the world"));
 	gbllist.addParam(RichInt(maxTextureMemoryParam(), 256, "Max Texture Memory (in MB)", "The maximum quantity of texture memory allowed to load mesh textures"));
+
+	gbllist.addParam(RichInt(startupWindowWidthParam(), 0, "Startup Window Width (in pixels)", "Window width on startup"));
+	gbllist.addParam(RichInt(startupWindowHeightParam(), 0, "Startup Window Height (in pixels)", "Window height on startup"));
 }
 
 void MainWindowSetting::updateGlobalParameterList(const RichParameterList& rpl)
@@ -1341,6 +1344,8 @@ void MainWindowSetting::updateGlobalParameterList(const RichParameterList& rpl)
 	if (MeshLabScalarTest<Scalarm>::doublePrecision())
 		highprecision = rpl.getBool(highPrecisionRendering());
 	maxTextureMemory = (std::ptrdiff_t) rpl.getInt(this->maxTextureMemoryParam()) * (float)(1024 * 1024);
+	startupWindowWidth = rpl.getInt(startupWindowWidthParam());
+	startupWindowHeight = rpl.getInt(startupWindowHeightParam());
 }
 
 void MainWindow::defaultPerViewRenderingData(MLRenderingData& dt) const


### PR DESCRIPTION
Meshlab always starts maximized. While that is great 95% of the time, depending on user's workspace it may be desired to start it with given dimensions to not cover other applications.

I added to Meshlab's customization setup the ability to do that. If the window dimensions are set to 0, which is the default, it will start maximized, like now. 

This was tested a lot and appears to work as desired. 