### PR TITLE
Update menus only after the viewers update to get the geometry right

### DIFF
--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -669,6 +669,8 @@ void GLArea::paintEvent(QPaintEvent* /*event*/)
     glFlush();
     glFinish();
     painter.endNativePainting();
+
+    emit currentViewerRefreshed();
 }
 
 void GLArea::displayMatrix(QPainter *painter, QRect areaRect)

--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -279,6 +279,7 @@ signals:
     void glareaClosed();					//someone has closed the glarea
 	void insertRenderingDataForNewlyGeneratedMesh(int);
     void currentViewerChanged(int currentId);
+    void currentViewerRefreshed();
 
 public slots:
 

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -475,8 +475,13 @@ void MainWindow::setUnsplit()
 		assert(mvc->viewerCounter() >1);
 		
 		mvc->removeView(mvc->currentView()->getId());
-		
-		updateMenus();
+
+		// After the view is removed and the remaining viewers
+		// are refreshed to fill the freed area, the geometry
+		// of these viewers becomes known, and then the menus
+		// can be updated correctly.
+		QObject::connect(mvc->currentView(), SIGNAL(currentViewerRefreshed()),
+				this, SLOT(updateMenus()));
 	}
 }
 


### PR DESCRIPTION
This is a fix for https://github.com/cnr-isti-vclab/meshlab/issues/1128. The fix is described there. 

