### PR TITLE
Unshadow variable.

### DIFF
--- a/src/meshlabplugins/io_base/save_project.cpp
+++ b/src/meshlabplugins/io_base/save_project.cpp
@@ -15,7 +15,7 @@ QDomElement matrix44mToXML(const Matrix44m &m, bool binary, QDomDocument &doc)
 	QDomText nd;
 	if (binary) {
 		QByteArray value = QByteArray::fromRawData((char *)m.V(), sizeof(Matrix44m::ScalarType) * 16).toBase64();
-		QDomText nd = doc.createTextNode(QString(value));
+		nd = doc.createTextNode(QString(value));
 	}
 	else {
 		QString row[4];


### PR DESCRIPTION
After “binary” case, the `QDomText nd` remains empty.