### PR TITLE
Add preference to show or hide trackball

### DIFF
--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -72,7 +72,7 @@ GLArea::GLArea(QWidget *parent, MultiViewer_Container *mvcont, RichParameterList
     takeSnapTile=false;
     activeDefaultTrackball=true;
     infoAreaVisible = true;
-    trackBallVisible = true;
+    trackBallVisible = glas.startupShowTrackball;
     currentShader = NULL;
     lastFilterRef = NULL;
     //lastEditRef = NULL;

--- a/src/meshlab/glarea_setting.cpp
+++ b/src/meshlab/glarea_setting.cpp
@@ -25,6 +25,7 @@ void GLAreaSetting::initGlobalParameterList(RichParameterList& defaultGlobalPara
 	defaultGlobalParamSet.addParam(RichFloat(pointSizeParam()	, 2.0, "Point Size","The base size of points when drawn"));
 
 	defaultGlobalParamSet.addParam(RichBool(wheelDirectionParam(), false, "Wheel Direction", "If true, inverts the direction of the mouse wheel for zooming in/out in the MeshLab canvas."));
+	defaultGlobalParamSet.addParam(RichBool(showTrackballParam(), true, "Show Trackball", "If true, show the trackball on startup."));
 	defaultGlobalParamSet.addParam(RichInt(matrixDecimalPrecisionParam(), 2, "Rotation Matrix Precision", "Number of decimal values shown in the rotation matrix"));
 }
 
@@ -49,6 +50,7 @@ void GLAreaSetting::updateGlobalParameterSet( const RichParameterList& rps )
 	pointSmooth = rps.getBool(this->pointSmoothParam());
 	pointSize = rps.getFloat(this->pointSizeParam());
 	wheelDirection = rps.getBool(this->wheelDirectionParam());
+        startupShowTrackball = rps.getBool(showTrackballParam());
 	matrixDecimalPrecision = rps.getInt(this->matrixDecimalPrecisionParam());
 	currentGlobalParamSet=&rps;
 }

--- a/src/meshlab/glarea_setting.h
+++ b/src/meshlab/glarea_setting.h
@@ -68,6 +68,8 @@ public:
 	inline static QString pointSizeParam() {return "MeshLab::Appearance::pointSize";}
 	bool wheelDirection;
 	inline static QString wheelDirectionParam() {return "MeshLab::Appearance::wheelDirection";}
+	bool startupShowTrackball;
+	inline static QString showTrackballParam() {return "MeshLab::Appearance::showTrackball";}
 	int matrixDecimalPrecision;
 	inline static QString matrixDecimalPrecisionParam() {return "MeshLab::Appearance::matrixDecimalPrecision";}
 


### PR DESCRIPTION
I found the trackball to be very useful for new users. But it can be also be distracting, as it is on top of the mesh.

This proposes a preference to hide or show the trackball. The default did not change. The user still can, as now, show or hide the trackball just for the current session, or set the new preference for future sessions. 