### PR TITLE
Mesh developability optimization filter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,7 @@ if(NOT DEFINED MESHLAB_PLUGINS) # it may be already defined in parent directory
 		meshlabplugins/filter_color_projection
 		meshlabplugins/filter_colorproc
 		meshlabplugins/filter_create
+		meshlabplugins/filter_developability
 		meshlabplugins/filter_dirt
 		meshlabplugins/filter_fractal
 		meshlabplugins/filter_func

--- a/src/meshlabplugins/filter_developability/CMakeLists.txt
+++ b/src/meshlabplugins/filter_developability/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright 2019-2020, Collabora, Ltd.
+# SPDX-License-Identifier: BSL-1.0
+
+
+set(SOURCES
+    filter_developability.cpp)
+
+set(HEADERS
+    filter_developability.h
+    remeshing.h
+    mesh_utils.h
+    energy.h
+    energy_grad.h
+    opt.h)
+
+add_meshlab_plugin(filter_developability ${SOURCES} ${HEADERS})

--- a/src/meshlabplugins/filter_developability/energy.h
+++ b/src/meshlabplugins/filter_developability/energy.h
@@ -1,0 +1,133 @@
+#ifndef FILTERDEVELOPABILITY_ENERGY_H
+#define FILTERDEVELOPABILITY_ENERGY_H
+
+#include <vector>
+
+#define FILTERDEVELOPABILITY_AVOID_BRANCHING
+
+
+template<typename MeshType>
+struct StarPartitioning
+{
+    Star<MeshType>* star;
+    int rBegin;   // index of the starting face within star for the first region
+    int rSize;    // cardinality of the first region
+};
+
+
+/*
+ * Compute the combinatorial energy of a mesh
+ * as defined in section 4.1.1 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+double combinatorialEnergy(MeshType& m,
+                           StarVertAttrHandle<MeshType>& vAttrStar)
+{
+    using VertexIterator = typename MeshType::VertexIterator;
+    
+    double totEnergy = 0.0;
+
+    for(VertexIterator vIter = m.vert.begin(); vIter != m.vert.end(); vIter++)
+        totEnergy += localCombinatorialEnergy(&(*vIter), m, vAttrStar);
+
+    return totEnergy;
+}
+
+
+/*
+ * Compute the combinatorial energy of a vertex star
+ * as defined in section 4.1.1 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+double localCombinatorialEnergy(typename MeshType::VertexPointer v,
+                                MeshType& m,
+                                StarVertAttrHandle<MeshType>& vAttrStar,
+                                StarPartitioning<MeshType>* outP = nullptr)
+{
+    double energy = -1.0;
+    StarPartitioning<MeshType> currP = {
+        &(vAttrStar[v]),    // star of faces around v
+        0,                  // rBegin
+        0                   // rSize
+    };
+
+    if(outP != nullptr)
+        outP->star = currP.star;
+
+    if(currP.star->size() <= 3 || v->IsB())
+        energy = 0.0;
+    else
+    {
+        // consider all possible cardinalities of a region resulting from a partitioning of the star
+        for(currP.rSize = 2; currP.rSize <= (currP.star->size() - 2); currP.rSize++)
+        {
+            // consider all possible regions having rSize faces and not crossing the vector boundaries.
+            // rBegin is the index of the first face in the region
+            for(currP.rBegin = 0; currP.rBegin < (currP.star->size() - currP.rSize); currP.rBegin++)
+            {                
+                double currRegionEnergy  = regionNormalDeviation(currP, 0, m);
+                double otherRegionEnergy = regionNormalDeviation(currP, 1, m);     
+
+                double currPartitioningEnergy;
+                #ifdef FILTERDEVELOPABILITY_AVOID_BRANCHING
+                    currPartitioningEnergy = std::max(currRegionEnergy, otherRegionEnergy);
+                #else
+                    currPartitioningEnergy = currRegionEnergy + otherRegionEnergy;
+                #endif
+
+                if(energy < 0 || currPartitioningEnergy < energy)
+                {
+                    energy = currPartitioningEnergy;
+                    if(outP != nullptr)
+                    {
+                        outP->rBegin = currP.rBegin;
+                        outP->rSize = currP.rSize;
+                    }
+                }
+            }
+        }
+    }
+
+    return energy;
+}
+
+
+/*
+ * Compute the normal deviation of a region of a vertex star
+ * as defined in equation 1 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+double regionNormalDeviation(const StarPartitioning<MeshType>& partitioning,
+                             bool region,
+                             MeshType& m)
+{
+    // compute the begin index and the cardinality of the desired region
+    int rBegin = region ? (partitioning.rBegin + partitioning.rSize)       : partitioning.rBegin;
+    int rSize  = region ? (partitioning.star->size() - partitioning.rSize) : partitioning.rSize;
+    int starSize = partitioning.star->size();
+
+    vcg::Point3d normDiff;
+    normDiff.SetZero();
+
+    double currRegionNormalDev;
+    double regionNormalDev = 0.0;
+
+    // iterate through each pair of faces within the region
+    for(int i = rBegin; i < (rBegin + rSize - 1); i++)
+        for(int j = i+1; j < (rBegin + rSize); j++)
+        {
+            normDiff = ( partitioning.star->at(i % starSize)->N() - partitioning.star->at(j % starSize)->N() );
+            currRegionNormalDev = normDiff.SquaredNorm();
+
+            #ifdef FILTERDEVELOPABILITY_AVOID_BRANCHING
+                regionNormalDev = std::max(regionNormalDev, currRegionNormalDev);
+            #else
+                regionNormalDev += ( currRegionNormalDev / std::pow(rSize, 2) );
+            #endif
+        }
+
+    return regionNormalDev;
+}
+
+
+#endif

--- a/src/meshlabplugins/filter_developability/energy_grad.h
+++ b/src/meshlabplugins/filter_developability/energy_grad.h
@@ -1,0 +1,116 @@
+#ifndef FILTERDEVELOPABILITY_ENERGYGRAD_H
+#define FILTERDEVELOPABILITY_ENERGYGRAD_H
+
+#include "mesh_utils.h"
+#include "energy.h"
+
+#include <vcg/math/matrix33.h>
+
+
+/*
+ * Compute the combinatorial energy of a mesh and its gradient
+ * as defined in section B.2 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+double combinatorialEnergyGrad(MeshType& m,
+                               AreaFaceAttrHandle<MeshType>& fAttrArea,
+                               StarVertAttrHandle<MeshType>& vAttrStar,
+                               GradientVertAttrHandle<MeshType>& vAttrGrad)
+{
+    using VertexIterator = typename MeshType::VertexIterator;
+
+    // reset the gradient associated with each vertex
+    for(VertexIterator vIter = m.vert.begin(); vIter != m.vert.end(); vIter++)
+        vAttrGrad[vIter].SetZero();
+
+    double currEnergy;
+    double totEnergy = 0.0;
+    StarPartitioning<MeshType> currPart;
+    for(VertexIterator vIter = m.vert.begin(); vIter != m.vert.end(); vIter++)
+    {
+        currEnergy = localCombinatorialEnergy(&(*vIter), m, vAttrStar, &currPart);
+        totEnergy += currEnergy;
+
+        if(currPart.star->size() <= 3 || vIter->IsB())
+            continue;
+
+        regionNormalDeviationGrad(&(*vIter), currPart, 0, m, fAttrArea, vAttrStar, vAttrGrad);
+        regionNormalDeviationGrad(&(*vIter), currPart, 1, m, fAttrArea, vAttrStar, vAttrGrad);
+    }
+
+    return totEnergy;
+}
+
+
+/*
+ * Compute the gradient of the normal deviation of a region
+ * as defined in section B.2 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+void regionNormalDeviationGrad(typename MeshType::VertexPointer v,
+                               StarPartitioning<MeshType>& partitioning,
+                               bool region,
+                               MeshType& m,
+                               AreaFaceAttrHandle<MeshType>& fAttrArea,
+                               StarVertAttrHandle<MeshType>& vAttrStar,
+                               GradientVertAttrHandle<MeshType>& vAttrGrad)
+{
+    using FacePointer = typename MeshType::FacePointer;
+    using VertexPointer = typename MeshType::VertexPointer;
+    
+    // compute the begin index and the cardinality of the desired region
+    int rBegin = region ? (partitioning.rBegin + partitioning.rSize)       : partitioning.rBegin;
+    int rSize  = region ? (partitioning.star->size() - partitioning.rSize) : partitioning.rSize;
+    int starSize = partitioning.star->size();
+    
+    FacePointer faceA, faceB;
+    vcg::Point3d normalDiff;
+
+    int faceA_vIndex, faceB_vIndex;
+    VertexPointer vertA, vertB;
+    
+    // iterate through each pair of faces within the region
+    for(int i = rBegin; i < (rBegin + rSize - 1); i++)
+        for(int j = i+1; j < (rBegin + rSize); j++)
+        {
+            faceA = vAttrStar[v][i % starSize];
+            faceB = vAttrStar[v][j % starSize];
+
+            normalDiff = faceA->N() - faceB->N();
+
+            for(faceA_vIndex = 0; faceA_vIndex < 3; faceA_vIndex++)
+            {
+                vertA = faceA->V(faceA_vIndex);
+                vAttrGrad[vertA] += (faceNormalGrad(faceA, faceA_vIndex, m, fAttrArea).transpose() * normalDiff * 2/std::pow(rSize, 2));
+            }
+
+            for(faceB_vIndex = 0; faceB_vIndex < 3; faceB_vIndex++)
+            {
+                vertB = faceB->V(faceB_vIndex);
+                vAttrGrad[vertB] -= (faceNormalGrad(faceB, faceB_vIndex, m, fAttrArea).transpose() * normalDiff* 2/std::pow(rSize, 2));
+            }            
+        }
+}
+
+
+/*
+ * Compute the gradient of the normal of a face wrt one of its vertices
+ * as defined in section B.1 of the paper "Developability of Triangle Meshes" by Stein et al. 2018
+ */
+template<typename MeshType>
+vcg::Matrix33d faceNormalGrad(typename MeshType::FacePointer f,
+                              int vIndex,
+                              MeshType& m,
+                              AreaFaceAttrHandle<MeshType>& fAttrArea)
+{    
+    vcg::Point3d oppositeEdge = f->V2(vIndex)->P() - f->V1(vIndex)->P();
+    vcg::Matrix33d grad;
+
+    grad.ExternalProduct(oppositeEdge ^ f->N(), f->N());
+    grad /= fAttrArea[f];
+
+    return grad;
+}
+
+
+#endif

--- a/src/meshlabplugins/filter_developability/filter_developability.cpp
+++ b/src/meshlabplugins/filter_developability/filter_developability.cpp
@@ -1,0 +1,239 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005                                                \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *   
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#include "filter_developability.h"
+#include "remeshing.h"
+#include "opt.h"
+#include "energy.h"
+
+FilterDevelopabilityPlugin::FilterDevelopabilityPlugin() 
+{ 
+    typeList = {FP_MAKE_DEVELOPABLE};
+
+    for(ActionIDType tt : types())
+        actionList.push_back(new QAction(filterName(tt), this));
+}
+
+FilterDevelopabilityPlugin::~FilterDevelopabilityPlugin()
+{
+}
+
+QString FilterDevelopabilityPlugin::pluginName() const
+{
+    return "FilterDevelopability";
+}
+
+QString FilterDevelopabilityPlugin::filterName(ActionIDType filterId) const
+{
+    switch(filterId) {
+    case FP_MAKE_DEVELOPABLE :
+        return "Make mesh developable";
+    default :
+        assert(0);
+        return QString();
+    }
+}
+
+QString FilterDevelopabilityPlugin::pythonFilterName(ActionIDType f) const
+{
+    switch(f) {
+    case FP_MAKE_DEVELOPABLE :
+        return "meshing_make_developable";
+    default :
+        assert(0);
+        return QString();
+    }
+}
+
+ QString FilterDevelopabilityPlugin::filterInfo(ActionIDType filterId) const
+{
+    switch(filterId) {
+    case FP_MAKE_DEVELOPABLE :
+        return "The filter improves the developability of the current two-manifold triangular mesh "
+               "by applying an optimization process that encourages each vertex star to form an hinge or a flat piece. "
+               "The resulting mesh is similar to the initial, but it is comprised of one or more developable pieces held toghether by highly regular seam curves, "
+               "i.e. path of edges which vertex stars did not form an hinge or a flat spot.<br>"
+               "Since small interior angles can have a negative impact on the outcome, an automatic remeshing that runs along the optimization can be enabled.<br>"
+               "When the obtained design is satisfactory, one may want to refine the quality of the seams and the developability of the surfaces "
+               "by alternating between regular midpoint subdivisions and further optimization rounds.<br>"
+               "For more details see:<br>"
+               "<b>Oded Stein, Eitan Grinspun and Keenan Crane</b><br>"
+               "<a href=\"https://doi.org/10.1145/3197517.3201303\">'Developability of triangle meshes'</a><br>"
+               "ACM Transactions on Graphics, Volume 37, Issue 4";
+    default :
+        assert(0);
+        return "Unknown Filter";
+    }
+}
+
+FilterDevelopabilityPlugin::FilterClass FilterDevelopabilityPlugin::getClass(const QAction *a) const
+{
+    switch(ID(a)) {
+    case FP_MAKE_DEVELOPABLE :
+        return FilterPlugin::Remeshing;
+    default :
+        assert(0);
+        return FilterPlugin::Generic;
+    }
+}
+
+FilterPlugin::FilterArity FilterDevelopabilityPlugin::filterArity(const QAction*) const
+{
+    return SINGLE_MESH;
+}
+
+int FilterDevelopabilityPlugin::getPreConditions(const QAction*) const
+{
+    return MeshModel::MM_NONE;
+}
+
+int FilterDevelopabilityPlugin::postCondition(const QAction*) const
+{
+    return MeshModel::MM_ALL;
+}
+
+RichParameterList FilterDevelopabilityPlugin::initParameterList(const QAction *action,const MeshModel &m)
+{
+    RichParameterList parlst;
+    QList<QString> optMethodsList{ "[F] Fixed stepsize", "[B] Backtracking line search" };
+    switch(ID(action)) {
+    case FP_MAKE_DEVELOPABLE :
+
+        parlst.addParam(RichEnum("OptMethod", 1, optMethodsList, "Gradient method", "The gradient method optimization algorithm to use"));
+        parlst.addParam(RichInt("MaxFunEvals", 400, "Max function evaluations", "The maximum number of function evaluation. Once reached, the optimization stops"));
+        parlst.addParam(RichFloat("Eps", 1e-5, "Stop threshold", "Optimization stops when the squared norm of the gradient is less than or equal to the accuracy"));
+        parlst.addParam(RichFloat("StepSize", 0.01, "Initial step size", "The initial step size of the opt method, fixed when using [F] optimizer"));
+        parlst.addParam(RichFloat("MinStepSize", 1e-10, "Min step size (B only)", "The minimum step size for the backtracking line search opt method"));
+        parlst.addParam(RichFloat("Tau", 0.8, "Tau (B only)", "Scaling factor of the step size for the backtracking line search opt method"));
+        parlst.addParam(RichFloat("M1", 1e-4, "Armijo constant (B only)", "The constant of the Armijo condition of the backtracking line search opt method"));
+        parlst.addParam(RichBool("EdgeFlips", true, "Apply edge flips", "Whether or not to apply edge flips when necessary during optimization"));
+        parlst.addParam(RichBool("EdgeCollapses", true, "Apply edge collapses", "Whether or not to apply edge collapses when necessary during optimization"));
+        parlst.addParam(RichFloat("AngleThreshold", 18, "Post-processing angle threshold (deg)", "The maximum angle under which an edge flip or an edge collapse must be performed during optimization"));
+        break;
+    default :
+        assert(0);
+    }
+    return parlst;
+}
+
+std::map<std::string, QVariant> FilterDevelopabilityPlugin::applyFilter(const QAction * action, const RichParameterList & parameters, MeshDocument &md, unsigned int& /*postConditionMask*/, vcg::CallBackPos *cb)
+{
+    switch(ID(action)) {
+    case FP_MAKE_DEVELOPABLE :
+        makeDevelopable(md,
+                        cb,
+                        parameters.getEnum("OptMethod"),
+                        parameters.getInt("MaxFunEvals"),
+                        parameters.getFloat("Eps"),
+                        parameters.getFloat("StepSize"),
+                        parameters.getFloat("MinStepSize"),
+                        parameters.getFloat("Tau"),
+                        parameters.getFloat("M1"),
+                        parameters.getBool("EdgeFlips"),
+                        parameters.getBool("EdgeCollapses"),
+                        parameters.getFloat("AngleThreshold"));
+        break;
+    default :
+        wrongActionCalled(action);
+    }
+    return std::map<std::string, QVariant>();
+}
+
+void FilterDevelopabilityPlugin::makeDevelopable(MeshDocument &md,
+                                                   vcg::CallBackPos *cb,
+                                                   int optMethod,
+                                                   int maxFunEval,
+                                                   double eps,
+                                                   double initialStepSize,
+                                                   double minStepSize,
+                                                   double tau,
+                                                   double m1,
+                                                   bool doEdgeFlip,
+                                                   bool doEdgeCollapse,
+                                                   double angleThreshold)
+{
+    // Get the current mesh, update FF topology and check 2-manifold precondition
+    
+    md.mm()->updateDataMask(MeshModel::MM_FACEFACETOPO);
+    CMeshO &m = md.mm()->cm;
+
+    if(vcg::tri::Clean<CMeshO>::CountNonManifoldEdgeFF(m) > 0)
+        throw MLException("non possible developability optimization because of non manifold edges");
+    if(vcg::tri::Clean<CMeshO>::CountNonManifoldVertexFF(m) > 0)
+        throw MLException("non possible developability optimization because of non manifold verties");
+
+    // Apply an initial remeshing if necessary
+
+    MeshPostProcessing<CMeshO> postProcessing(doEdgeFlip, doEdgeCollapse, vcg::math::ToRad(angleThreshold));
+    if(postProcessing.process(m))
+        log("An initial remeshing has been applied");
+
+    // Temporarily move the mesh to origin and scale the diagonal of the bounding box to unit
+
+    double boundingBoxDiag;
+    vcg::Point3d boundingBoxCenter;
+
+    vcg::tri::UpdateBounding<CMeshO>::Box(m);
+    boundingBoxDiag = m.bbox.Diag();
+    boundingBoxCenter = m.bbox.Center();
+    vcg::tri::UpdatePosition<CMeshO>::Translate(m, -boundingBoxCenter);
+    vcg::tri::UpdatePosition<CMeshO>::Scale(m, 1.0 / boundingBoxDiag);
+
+    // Proceed to the actual optimization
+
+    vcg::tri::UpdateFlags<CMeshO>::VertexBorderFromFaceAdj(m);
+    Optimizer<CMeshO>* opt;
+
+    if(optMethod == 0)
+        opt = new FixedStepOpt<CMeshO>(m, maxFunEval, eps, initialStepSize);
+    else
+        opt = new BacktrackingOpt<CMeshO>(m, maxFunEval, eps, initialStepSize, minStepSize, tau, m1);
+
+    while(opt->step())
+    {
+        if(optMethod == 0)
+            log("[F] nFunEvals:%d gradSqNorm:%f energy:%f", opt->getNFunEval(), opt->getGradientSqNorm(), opt->getEnergy());
+        else
+            log("[B] nFunEvals:%d stepSize:%f gradSqNorm:%f energy:%f", opt->getNFunEval(), opt->getStepSize(), opt->getGradientSqNorm(), opt->getEnergy());
+
+        if(optMethod == 1 || (opt->getNFunEval() % 10 == 0))
+            cb(100 * opt->getNFunEval() / maxFunEval, "Optimizing developability energy...");
+                
+        if(postProcessing.process(m))
+        {
+            log("Remeshing applied");
+            opt->reset();
+        }
+    }
+
+    delete opt;
+
+    // Reset original position and scale of the mesh
+
+    vcg::tri::UpdatePosition<CMeshO>::Scale(m, boundingBoxDiag);
+    vcg::tri::UpdatePosition<CMeshO>::Translate(m, boundingBoxCenter);
+
+    md.mm()->updateBoxAndNormals();
+}
+
+MESHLAB_PLUGIN_NAME_EXPORTER(FilterDevelopabilityPlugin)

--- a/src/meshlabplugins/filter_developability/filter_developability.h
+++ b/src/meshlabplugins/filter_developability/filter_developability.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+* MeshLab                                                           o o     *
+* A versatile mesh processing toolbox                             o     o   *
+*                                                                _   O  _   *
+* Copyright(C) 2005                                                \/)\/    *
+* Visual Computing Lab                                            /\/|      *
+* ISTI - Italian National Research Council                           |      *
+*                                                                    \      *
+* All rights reserved.                                                      *
+*                                                                           *
+* This program is free software; you can redistribute it and/or modify      *   
+* it under the terms of the GNU General Public License as published by      *
+* the Free Software Foundation; either version 2 of the License, or         *
+* (at your option) any later version.                                       *
+*                                                                           *
+* This program is distributed in the hope that it will be useful,           *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             *
+* GNU General Public License (http://www.gnu.org/licenses/gpl.txt)          *
+* for more details.                                                         *
+*                                                                           *
+****************************************************************************/
+
+#ifndef FILTERDEVELOPABILITY_PLUGIN_H
+#define FILTERDEVELOPABILITY_PLUGIN_H
+
+#include <common/plugins/interfaces/filter_plugin.h>
+
+class FilterDevelopabilityPlugin : public QObject, public FilterPlugin
+{
+    Q_OBJECT
+    MESHLAB_PLUGIN_IID_EXPORTER(FILTER_PLUGIN_IID)
+    Q_INTERFACES(FilterPlugin)
+
+public:
+    enum { FP_MAKE_DEVELOPABLE  } ;
+
+    FilterDevelopabilityPlugin();
+    virtual ~FilterDevelopabilityPlugin();
+
+    QString pluginName() const;
+
+    QString filterName(ActionIDType filter) const;
+    QString pythonFilterName(ActionIDType f) const;
+    QString filterInfo(ActionIDType filter) const;
+    FilterClass getClass(const QAction* a) const;
+    FilterArity filterArity(const QAction*) const;
+    int getPreConditions(const QAction *) const;
+    int postCondition(const QAction* ) const;
+    RichParameterList initParameterList(const QAction*, const MeshModel &/*m*/);
+    std::map<std::string, QVariant> applyFilter(
+            const QAction* action,
+            const RichParameterList & parameters,
+            MeshDocument &md,
+            unsigned int& postConditionMask,
+            vcg::CallBackPos * cb);
+
+private:
+    void makeDevelopable(MeshDocument &md,
+                          vcg::CallBackPos *cb,
+                          int optMethod,
+                          int maxFunEval,
+                          double eps,
+                          double initialStepSize,
+                          double minStepSize,
+                          double tau,
+                          double m1,
+                          bool doEdgeFlip,
+                          bool doEdgeCollapse,
+                          double angleThreshold);
+};
+
+#endif

--- a/src/meshlabplugins/filter_developability/mesh_utils.h
+++ b/src/meshlabplugins/filter_developability/mesh_utils.h
@@ -13,13 +13,13 @@ template<typename MeshType>
 using Star = std::vector<typename MeshType::FacePointer>;
 
 template<typename MeshType>
-using StarVertAttrHandle = typename MeshType::PerVertexAttributeHandle<Star<MeshType>>;
+using StarVertAttrHandle = typename MeshType:: template PerVertexAttributeHandle<Star<MeshType>>;
 
 template<typename MeshType>
-using AreaFaceAttrHandle = typename MeshType::PerFaceAttributeHandle<double>;
+using AreaFaceAttrHandle = typename MeshType:: template PerFaceAttributeHandle<double>;
 
 template<typename MeshType>
-using GradientVertAttrHandle = typename MeshType::PerVertexAttributeHandle<vcg::Point3d>;
+using GradientVertAttrHandle = typename MeshType:: template PerVertexAttributeHandle<vcg::Point3d>;
 
 
 template<typename MeshType>

--- a/src/meshlabplugins/filter_developability/mesh_utils.h
+++ b/src/meshlabplugins/filter_developability/mesh_utils.h
@@ -1,0 +1,74 @@
+#ifndef FILTERDEVELOPABILITY_MESHUTILS_H
+#define FILTERDEVELOPABILITY_MESHUTILS_H
+
+#include <vector>
+#include <vcg/space/point3.h>
+#include <vcg/simplex/face/pos.h>
+#include <vcg/simplex/face/topology.h>
+#include <vcg/complex/algorithms/update/flag.h>
+#include <vcg/complex/algorithms/update/normal.h>
+
+
+template<typename MeshType>
+using Star = std::vector<typename MeshType::FacePointer>;
+
+template<typename MeshType>
+using StarVertAttrHandle = typename MeshType::PerVertexAttributeHandle<Star<MeshType>>;
+
+template<typename MeshType>
+using AreaFaceAttrHandle = typename MeshType::PerFaceAttributeHandle<double>;
+
+template<typename MeshType>
+using GradientVertAttrHandle = typename MeshType::PerVertexAttributeHandle<vcg::Point3d>;
+
+
+template<typename MeshType>
+void updateFaceStars(MeshType& m, StarVertAttrHandle<MeshType>& stars)
+{
+    using VertexPointer = typename MeshType::VertexPointer;
+    using VertexIterator = typename MeshType::VertexIterator;
+    using FaceIterator = typename MeshType::FaceIterator;
+    using FaceType = typename MeshType::FaceType;
+    
+    int vIndex;
+    VertexPointer v;
+    std::vector<vcg::face::Pos<FaceType>> currStarPos;
+
+    for(VertexIterator vIter = m.vert.begin(); vIter != m.vert.end(); vIter++)
+        stars[vIter].clear();
+
+    vcg::tri::UpdateFlags<MeshType>::VertexClearV(m);
+    for(FaceIterator fIter = m.face.begin(); fIter != m.face.end(); fIter++)
+    {        
+        for(vIndex = 0; vIndex < 3; vIndex++)
+        {
+            v = fIter->V(vIndex);
+            if(v->IsV())
+                continue;
+            v->SetV();
+
+            vcg::face::VFOrderedStarFF(vcg::face::Pos<FaceType>(&(*fIter), v), currStarPos);
+            for(vcg::face::Pos<FaceType> p : currStarPos)
+                stars[v].push_back(p.F());
+        }
+    }
+}
+
+template<typename MeshType>
+void updateNormalsAndAreas(MeshType& m, AreaFaceAttrHandle<MeshType>& areas)
+{
+    using FaceIterator = typename MeshType::FaceIterator;
+    
+    vcg::tri::UpdateNormal<MeshType>::PerFace(m);
+    double currNorm;
+    
+    for(FaceIterator fIter = m.face.begin(); fIter != m.face.end(); fIter++)
+    {
+        currNorm = fIter->N().Norm();
+        areas[fIter] = currNorm / 2.0;
+        fIter->N().Normalize();
+    }
+}
+
+
+#endif

--- a/src/meshlabplugins/filter_developability/opt.h
+++ b/src/meshlabplugins/filter_developability/opt.h
@@ -1,0 +1,232 @@
+#ifndef FILTERDEVELOPABILITY_OPT_H
+#define FILTERDEVELOPABILITY_OPT_H
+
+#include "mesh_utils.h"
+#include "energy.h"
+#include "energy_grad.h"
+
+#include <vcg/complex/allocate.h>
+#include <vcg/complex/append.h>
+
+#include <vcg/complex/algorithms/update/flag.h>
+#include <vcg/complex/algorithms/update/topology.h>
+
+
+/*
+ * Gradient method optimizer interface
+ */
+template<typename MeshType>
+class Optimizer
+{
+public:
+    Optimizer(MeshType& m,
+              double stepSize) :
+        m(m),
+        stepSize(stepSize),
+        nFunEval(0)
+    {
+        vAttrStar = vcg::tri::Allocator<MeshType>:: template GetPerVertexAttribute<Star<MeshType>>(m, std::string("Star"));
+        vAttrGrad = vcg::tri::Allocator<MeshType>:: template GetPerVertexAttribute<vcg::Point3d>(m, std::string("Gradient"));
+        fAttrArea = vcg::tri::Allocator<MeshType>:: template GetPerFaceAttribute<double>(m, std::string("Area"));
+    }
+
+    /*
+     * Routine that must be called when the mesh geometry and/or topology changes
+     */
+    virtual void reset() = 0;
+
+    /*
+     * Perform an optimization step; returns true iff another step can be performed
+     */
+    virtual bool step() = 0;
+
+    void updateGradientSqNorm()
+    {
+        gradSqNorm = 0.0;
+        
+        for(size_t v = 0; v < m.VN(); v++)
+            for(int i = 0; i < 3; i++)
+                gradSqNorm += std::pow(vAttrGrad[v][i], 2);
+    }
+
+    double getGradientSqNorm() { return gradSqNorm; }
+    double getStepSize() { return stepSize; }
+    double getEnergy() { return energy; }
+    int getNFunEval() { return nFunEval; }
+
+protected:
+    MeshType& m;
+    AreaFaceAttrHandle<MeshType> fAttrArea;
+    StarVertAttrHandle<MeshType> vAttrStar;
+    GradientVertAttrHandle<MeshType> vAttrGrad;
+    double stepSize;
+    double gradSqNorm;
+    double energy;
+    int nFunEval;
+};
+
+
+/*
+ * Gradient method optimization with fixed step size
+ */
+template<typename MeshType>
+class FixedStepOpt : public Optimizer<MeshType>
+{
+    using Optimizer<MeshType>::m;
+    using Optimizer<MeshType>::fAttrArea;
+    using Optimizer<MeshType>::vAttrStar;
+    using Optimizer<MeshType>::vAttrGrad;
+    using Optimizer<MeshType>::stepSize;
+    using Optimizer<MeshType>::gradSqNorm;
+    using Optimizer<MeshType>::energy;
+    using Optimizer<MeshType>::nFunEval;
+    using Optimizer<MeshType>::updateGradientSqNorm;
+
+public:
+    FixedStepOpt(MeshType& m,
+                 int maxFunEval,
+                 double eps,
+                 double stepSize) :
+        Optimizer<MeshType>(m, stepSize),
+        maxFunEval(maxFunEval),
+        eps(eps)
+    {
+        reset();
+    }
+
+    void reset() override
+    {
+        updateFaceStars(m, vAttrStar);
+        updateNormalsAndAreas(m, fAttrArea);
+        energy = combinatorialEnergyGrad(m, fAttrArea, vAttrStar, vAttrGrad);
+        updateGradientSqNorm();
+    }
+
+    bool step() override
+    {
+        if(nFunEval >= maxFunEval || gradSqNorm <= eps)
+            return false;
+        
+        for(size_t v = 0; v < m.VN(); v++)
+            m.vert[v].P() -= (vAttrGrad[v] * stepSize);
+
+        updateNormalsAndAreas(m, fAttrArea);
+        energy = combinatorialEnergyGrad(m, fAttrArea, vAttrStar, vAttrGrad);
+        updateGradientSqNorm();
+        nFunEval++;
+
+        return true;
+    }
+
+private: 
+    int maxFunEval;
+    double eps;
+};
+
+
+/*
+ * Gradient method optimization with backtracking line search (Armijo condition)
+ */
+template<typename MeshType>
+class BacktrackingOpt : public Optimizer<MeshType>
+{
+    using Optimizer<MeshType>::m;
+    using Optimizer<MeshType>::fAttrArea;
+    using Optimizer<MeshType>::vAttrStar;
+    using Optimizer<MeshType>::vAttrGrad;
+    using Optimizer<MeshType>::stepSize;
+    using Optimizer<MeshType>::gradSqNorm;
+    using Optimizer<MeshType>::energy;
+    using Optimizer<MeshType>::nFunEval;
+    using Optimizer<MeshType>::updateGradientSqNorm;
+
+public:
+    BacktrackingOpt(MeshType& m,
+                    int maxFunEval,
+                    double eps,
+                    double initialStepSize,
+                    double minStepSize,
+                    double tau,
+                    double armijoM1) :
+        Optimizer<MeshType>(m, initialStepSize),
+        maxFunEval(maxFunEval),
+        eps(eps),
+        initialStepSize(initialStepSize),
+        minStepSize(minStepSize),
+        tau(tau),
+        armijoM1(armijoM1)
+    {
+        reset();
+    }
+
+    void reset() override
+    {
+        tmpVP.clear();
+        tmpVP.reserve(m.vert.size());
+        for(size_t v = 0; v < m.vert.size(); v++)
+            tmpVP.push_back(m.vert[v].cP());
+
+        updateFaceStars(m, vAttrStar);
+        updateNormalsAndAreas(m, fAttrArea);
+        energy = combinatorialEnergyGrad(m, fAttrArea, vAttrStar, vAttrGrad);
+        updateGradientSqNorm();
+    }
+
+    bool step() override
+    {                  
+        if(nFunEval >= maxFunEval || gradSqNorm <= eps)
+            return false;
+        
+        double LS_energy, LS_stepSize;
+        // compute the current tomography deriv as the dot prod between grad and search direction -grad
+        // == minus the squared l2 norm of the gradient
+        double tomographyDeriv = -(gradSqNorm);
+
+        for(LS_stepSize = initialStepSize; LS_stepSize > minStepSize; LS_stepSize *= tau)
+        {
+            for(size_t v = 0; v < m.vert.size(); v++)
+                m.vert[v].P() = tmpVP[v] - vAttrGrad[v] * LS_stepSize;
+
+            updateNormalsAndAreas(m, fAttrArea);
+            LS_energy = combinatorialEnergy(m, vAttrStar);
+            nFunEval++;
+
+            // check Armijo condition
+            if(LS_energy <= energy + armijoM1 * LS_stepSize * tomographyDeriv)
+                break;
+
+            if(nFunEval >= maxFunEval)
+            {
+                for(size_t v = 0; v < m.vert.size(); v++)
+                    m.vert[v].P() = tmpVP[v];
+                    
+                updateNormalsAndAreas(m, fAttrArea);
+
+                return false;
+            }
+        }
+
+        for(size_t v = 0; v < m.vert.size(); v++)
+            tmpVP[v] = m.vert[v].cP();
+
+        stepSize = LS_stepSize;
+        energy = LS_energy;
+        combinatorialEnergyGrad(m, fAttrArea, vAttrStar, vAttrGrad);
+        updateGradientSqNorm();
+        nFunEval++;
+
+        return true;
+    }
+
+private:
+    std::vector<vcg::Point3d> tmpVP;
+    int maxFunEval;
+    double eps;
+    double initialStepSize;
+    double minStepSize;
+    double tau;
+    double armijoM1;
+};
+
+
+#endif

--- a/src/meshlabplugins/filter_developability/remeshing.h
+++ b/src/meshlabplugins/filter_developability/remeshing.h
@@ -1,0 +1,98 @@
+#ifndef FILTERDEVELOPABILITY_REMESHING_H
+#define FILTERDEVELOPABILITY_REMESHING_H
+
+#include "mesh_utils.h"
+
+
+/*
+ * To improve numerical stability of the energy optimization, meshes should not present
+ * small interior angles;
+ * this class implements a post-processing phase that can be applied between iterations
+ * in order to get rid of these angles by means of edge flipping and/or edge collapsing
+ */
+template <class MeshType>
+class MeshPostProcessing
+{
+public:
+    MeshPostProcessing(bool doEdgeFlipping,
+                       bool doEdgeCollapsing,
+                       double angleThreshold) :
+        doEdgeFlipping(doEdgeFlipping),
+        doEdgeCollapsing(doEdgeCollapsing),
+        angleThreshold(angleThreshold)  // the radiants under which the angle is considered to be small
+    {}
+
+    /*
+     * Perform the post-processing on a mesh
+     */
+    bool process(MeshType& m)
+    {
+        typedef typename MeshType::FaceType FaceType;
+        typedef typename MeshType::FaceIterator FaceIterator;
+        
+        double faceAngles[3];
+        int edgeToFlip;
+        int edgeToCollapse;
+        bool meshModified = false;
+        
+        for(FaceIterator fIter = m.face.begin(); fIter != m.face.end(); fIter++)
+        {
+            if(fIter->IsD())
+                continue;
+            
+            faceAngles[0] = vcg::face::WedgeAngleRad<FaceType>(*fIter, 0);
+            faceAngles[1] = vcg::face::WedgeAngleRad<FaceType>(*fIter, 1);
+            faceAngles[2] = vcg::face::WedgeAngleRad<FaceType>(*fIter, 2);
+
+            edgeToFlip = -1;
+            edgeToCollapse = -1;
+            for(int i = 0; i < 2; i++)
+                if(faceAngles[i] < angleThreshold)
+                {
+                    if(faceAngles[(i+1)%3] < angleThreshold)
+                    {
+                        edgeToFlip = i;
+                        break;
+                    }
+                    else if(faceAngles[(i-1)%3] < angleThreshold)
+                    {
+                        edgeToFlip = (i-1)%3;
+                        break;
+                    }
+                    else
+                    {
+                        edgeToCollapse = (i+1)%3;
+                        break;
+                    }
+                }
+
+            if(doEdgeFlipping && edgeToFlip >= 0 && vcg::face::CheckFlipEdge(*fIter, edgeToFlip))
+            {
+                vcg::face::FlipEdge<FaceType>(*fIter, edgeToFlip);
+                meshModified = true;
+            }
+            else if(doEdgeCollapsing && edgeToCollapse >= 0 && vcg::face::FFLinkCondition(*fIter, edgeToCollapse))
+            {
+                vcg::face::FFEdgeCollapse<MeshType>(m, *fIter, edgeToCollapse);
+                meshModified = true;
+            }
+        }
+
+        if(meshModified)
+        {
+            vcg::tri::Allocator<MeshType>::CompactFaceVector(m);
+            vcg::tri::Allocator<MeshType>::CompactVertexVector(m);
+            vcg::tri::UpdateFlags<MeshType>::VertexBorderFromFaceAdj(m);
+        }
+
+        return meshModified;
+    }
+
+private:
+    bool doEdgeFlipping;
+    bool doEdgeCollapsing;
+    double angleThreshold;
+};
+
+
+#endif


### PR DESCRIPTION
Hey there!
This PR adds a new filter for improving the developability of two-manifold triangle meshes, based on the surface modeling approach proposed in the paper '_Developability of triangle meshes_' [DOI 10.1145/3197517.3201303](https://doi.org/10.1145/3197517.3201303)