### PR TITLE
Meshlab #780: fix crash when closing project window

### DIFF
--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -1811,7 +1811,9 @@ void MainWindow::newProject(const QString& projName)
 {
 	if (gpumeminfo == NULL)
 		return;
-	MultiViewer_Container *mvcont = new MultiViewer_Container(*gpumeminfo,mwsettings.highprecision,mwsettings.perbatchprimitives,mwsettings.minpolygonpersmoothrendering,mdiarea);
+
+	// The parent of mvcont is set to null, because mdiArea will put it into a QMDISubWindow that will take ownership
+	MultiViewer_Container *mvcont = new MultiViewer_Container(*gpumeminfo,mwsettings.highprecision,mwsettings.perbatchprimitives,mwsettings.minpolygonpersmoothrendering,nullptr);
 	connect(&mvcont->meshDoc,SIGNAL(meshAdded(int)),this,SLOT(meshAdded(int)));
 	connect(&mvcont->meshDoc,SIGNAL(meshRemoved(int)),this,SLOT(meshRemoved(int)));
 	connect(&mvcont->meshDoc, SIGNAL(documentUpdated()), this, SLOT(documentUpdateRequested()));

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -1812,7 +1812,8 @@ void MainWindow::newProject(const QString& projName)
 	if (gpumeminfo == NULL)
 		return;
 
-	// The parent of mvcont is set to null, because mdiArea will put it into a QMDISubWindow that will take ownership
+        // The parent of mvcont is set to null, because mdiarea->addSubWindow
+        // will put it into a QMDISubWindow that will take ownership
 	MultiViewer_Container *mvcont = new MultiViewer_Container(*gpumeminfo,mwsettings.highprecision,mwsettings.perbatchprimitives,mwsettings.minpolygonpersmoothrendering,nullptr);
 	connect(&mvcont->meshDoc,SIGNAL(meshAdded(int)),this,SLOT(meshAdded(int)));
 	connect(&mvcont->meshDoc,SIGNAL(meshRemoved(int)),this,SLOT(meshRemoved(int)));

--- a/src/meshlab/multiViewer_Container.cpp
+++ b/src/meshlab/multiViewer_Container.cpp
@@ -80,7 +80,7 @@ MultiViewer_Container::~MultiViewer_Container()
 	
     //WARNING!!!! Here just the pointer to the MLSceneGLSharedDataContext is destroyed.
     // The data contained in the GPU gets deallocated in the closeEvent function.
-    delete scenecontext;
+    scenecontext->deleteLater();
 }
 
 int MultiViewer_Container::getNextViewerId(){


### PR DESCRIPTION
This pull request fixes the issue in #780 , where closing a project window will crash meshlab. The reason for the crash is an inconsistent ownership: when `mvcont` is created, its parent is specified as the `mdiarea`. When `mvcont` is added as a subWindow to the `mdiarea`, the `mdiarea` internally creates a `QMdiSubWindow` and puts `mvcont` as its internal widget, which will also take ownership of mvcont.

I tested the fix on windows 10 (msvc2019) and ubuntu 22.04:
* Open meshlab
* Close the project window
* Open a new project
* Close it again
* Repeatedly open and close, sometimes add meshes
* No crash happened
I couldn't test on MAC. If there are more tests that should be done, let me know and I will try to do them also.