### PR TITLE
Link to muparser help in several filter dialogs

### DIFF
--- a/src/meshlabplugins/filter_func/filter_func.cpp
+++ b/src/meshlabplugins/filter_func/filter_func.cpp
@@ -120,20 +120,22 @@ QString FilterFunctionPlugin::pythonFilterName(ActionIDType f) const
 }
 
 const QString PossibleOperators(
-	"<br>It's possible to use parenthesis <b>()</b>, and predefined operators:<br>"
+	"<br>It's possible to use parenthesis <b>()</b>, and predefined "
+	"<a href='https://beltoforion.de/en/muparser/features.php#idDef2'>muparser built-in operators</a>, like:<br>"
 	"<b>&&</b> (logic and), <b>||</b> (logic or), <b>&lt;</b>, <b>&lt;=</b>, <b>></b>, <b>>=</b>, "
-	"<b>!=</b> (not equal), <b>==</b> (equal), <b>_?_:_</b> (c/c++ ternary operator)<br><br>");
+	"<b>!=</b> (not equal), <b>==</b> (equal), <b>_?_:_</b> (c/c++ ternary operator).<br><br>");
 
 const QString PerVertexAttributeString(
-	"It's possible to use the following per-vertex variables in the expression:<br>"
+	"It's possible to use <a href='https://beltoforion.de/en/muparser/features.php#idDef1'>muparser built-in functions</a>"
+	"and the following per-vertex variables in the expression:<br>"
 	"<b>x,y,z</b> (position), <b>nx,ny,nz</b> (normal), <b>r,g,b,a</b> (color), <b>q</b> "
 	"(quality), <b>vi</b> (vertex index), <b>vtu,vtv,ti</b> (texture coords and texture "
 	"index), <b>vsel</b> (is the vertex selected? 1 yes, 0 no) "
 	"and all custom <i>vertex attributes</i> already defined by user.<br>");
 
 const QString PerFaceAttributeString(
-	"It's possible to use the following per-face variables, or variables associated to the three "
-	"vertex of every face:<br>"
+	"It's possible to use <a href='https://beltoforion.de/en/muparser/features.php#idDef1'>muparser built-in functions</a>"
+	"and the following per-face or per-vertex variables:<br>"
 	"<b>x0,y0,z0</b> for the first vertex position, <b>x1,y1,z1</b> for the second vertex "
 	"position, <b>x2,y2,z2</b> for the third vertex position, "
 	"<b>nx0,ny0,nz0 nx1,ny1,nz1 nx2,ny2,nz2</b> for vertex normals, <b>r0,g0,b0,a0 r1,g1,b1,a1 "


### PR DESCRIPTION

Add a link to [muparser help](https://beltoforion.de/en/muparser/features.php#idDef1) in the help of several "per-face/vertex xxx functions" filter dialog, which will be rendered like this:

It's possible to use [muparser built-in functions](https://beltoforion.de/en/muparser/features.php#idDef1) and the following per-face or per-vertex variables:

**x0,y0,z0** for the first vertex position, **x1,y1,z1** for the second vertex position, **x2,y2,z2** for the third vertex position, **nx0,ny0,nz0 nx1,ny1,nz1 nx2,ny2,nz2** for vertex normals, **r0,g0,b0,a0 r1,g1,b1,a1 ** for vertex colors ...
