### PR TITLE
 Add rnd() and randInt(n) functions to muparse 

### DIFF
--- a/src/meshlabplugins/filter_func/filter_func.cpp
+++ b/src/meshlabplugins/filter_func/filter_func.cpp
@@ -33,6 +33,20 @@
 using namespace mu;
 using namespace vcg;
 
+std::random_device randomDev;
+std::default_random_engine rndEngine(randomDev());
+//Function to generate a random double number in [0..1) interval
+double ML_Rnd() { return std::generate_canonical<double, 24>(rndEngine); }
+//Function to generate a random integer number in [0..a) interval
+double ML_RandInt(const double a) { return std::floor(a*MyRnd()); }
+
+//Add rnd() and randint() custom functions to a mu::Parser
+void setCustomFunctions(mu::Parser& p)
+{
+	p.DefineFun("rnd", ML_Rnd);
+	p.DefineFun("randInt", ML_RandInt);
+}
+
 // Constructor
 FilterFunctionPlugin::FilterFunctionPlugin()
 {
@@ -703,7 +717,9 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 
 		// muparser initialization and explicitly define parser variables
 		Parser p;
+
 		setPerVertexVariables(p, m.cm);
+		setCustomFunctions(p);
 
 		// set expression inserted by user as string (required by muparser)
 		p.SetExpr(wexpr);
@@ -749,7 +765,8 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		// muparser initialization and explicitly define parser variables
 		Parser p;
 		setPerFaceVariables(p, m.cm);
-
+		setCustomFunctions(p);
+		
 		// set expression inserted by user as string (required by muparser)
 		p.SetExpr(conversion::fromStringToWString(select.toStdString()));
 
@@ -817,11 +834,15 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		// muparser initialization and explicitly define parser variables
 		// function for x,y and z must use different parser and variables
 		Parser p1, p2, p3, p4;
-
 		setPerVertexVariables(p1, m.cm);
 		setPerVertexVariables(p2, m.cm);
 		setPerVertexVariables(p3, m.cm);
 		setPerVertexVariables(p4, m.cm);
+
+		setCustomFunctions(p1);
+		setCustomFunctions(p2);
+		setCustomFunctions(p3);
+		setCustomFunctions(p4);
 
 		p1.SetExpr(conversion::fromStringToWString(func_x));
 		p2.SetExpr(conversion::fromStringToWString(func_y));
@@ -918,6 +939,9 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		Parser p;
 		setPerVertexVariables(p, m.cm);
 
+		//Add rnd() and randInt() internal functions
+		setCustomFunctions(p);
+
 		// set expression to calc with parser
 		p.SetExpr(conversion::fromStringToWString(func_q));
 
@@ -977,6 +1001,8 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		Parser pu, pv;
 		setPerVertexVariables(pu, m.cm);
 		setPerVertexVariables(pv, m.cm);
+		setCustomFunctions(pu);
+		setCustomFunctions(pv);
 
 		// set expression to calc with parser
 #ifdef _UNICODE
@@ -1035,6 +1061,12 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		setPerFaceVariables(pv1, m.cm);
 		setPerFaceVariables(pu2, m.cm);
 		setPerFaceVariables(pv2, m.cm);
+		setCustomFunctions(pu0);
+		setCustomFunctions(pv0);
+		setCustomFunctions(pu1);
+		setCustomFunctions(pv1);
+		setCustomFunctions(pu2);
+		setCustomFunctions(pv2);
 
 		// set expression to calc with parser
 		pu0.SetExpr(conversion::fromStringToWString(func_u0));
@@ -1084,6 +1116,10 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		setPerFaceVariables(p_nx, m.cm);
 		setPerFaceVariables(p_ny, m.cm);
 		setPerFaceVariables(p_nz, m.cm);
+		setCustomFunctions(p_nx);
+		setCustomFunctions(p_ny);
+		setCustomFunctions(p_nz);
+			
 		p_nx.SetExpr(conversion::fromStringToWString(func_nx));
 		p_ny.SetExpr(conversion::fromStringToWString(func_ny));
 		p_nz.SetExpr(conversion::fromStringToWString(func_nz));
@@ -1156,6 +1192,10 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		setPerFaceVariables(p2, m.cm);
 		setPerFaceVariables(p3, m.cm);
 		setPerFaceVariables(p4, m.cm);
+		setCustomFunctions(p1);
+		setCustomFunctions(p2);
+		setCustomFunctions(p3);
+		setCustomFunctions(p4);
 
 		p1.SetExpr(conversion::fromStringToWString(func_r));
 		p2.SetExpr(conversion::fromStringToWString(func_g));
@@ -1229,6 +1269,7 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		// muparser initialization and define custom variables
 		Parser pf;
 		setPerFaceVariables(pf, m.cm);
+		setCustomFunctions(pf);
 
 		// set expression to calc with parser
 		pf.SetExpr(conversion::fromStringToWString(func_q));
@@ -1288,6 +1329,7 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 
 		Parser p;
 		setPerVertexVariables(p, m.cm);
+		setCustomFunctions(p);
 
 		p.SetExpr(conversion::fromStringToWString(expr));
 
@@ -1340,6 +1382,7 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 			h = tri::Allocator<CMeshO>::AddPerFaceAttribute<Scalarm>(m.cm, name);
 		Parser p;
 		setPerFaceVariables(p, m.cm);
+		setCustomFunctions(p);		
 		p.SetExpr(conversion::fromStringToWString(expr));
 
 		time_t start = clock();
@@ -1386,6 +1429,10 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		setPerVertexVariables(p_x, m.cm);
 		setPerVertexVariables(p_y, m.cm);
 		setPerVertexVariables(p_z, m.cm);
+		setCustomFunctions(p_x);
+		setCustomFunctions(p_y);
+		setCustomFunctions(p_z);
+
 		p_x.SetExpr(conversion::fromStringToWString(x_expr));
 		p_y.SetExpr(conversion::fromStringToWString(y_expr));
 		p_z.SetExpr(conversion::fromStringToWString(z_expr));
@@ -1445,6 +1492,9 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 		setPerFaceVariables(p_x, m.cm);
 		setPerFaceVariables(p_y, m.cm);
 		setPerFaceVariables(p_z, m.cm);
+		setCustomFunctions(p_x);
+		setCustomFunctions(p_y);
+		setCustomFunctions(p_z);
 		p_x.SetExpr(conversion::fromStringToWString(x_expr));
 		p_y.SetExpr(conversion::fromStringToWString(y_expr));
 		p_z.SetExpr(conversion::fromStringToWString(z_expr));
@@ -1526,6 +1576,8 @@ std::map<std::string, QVariant> FilterFunctionPlugin::applyFilter(
 
 		Parser p;
 		double x, y, z;
+		setCustomFunctions(p);
+		
 		p.DefineVar(conversion::fromStringToWString("x"), &x);
 		p.DefineVar(conversion::fromStringToWString("y"), &y);
 		p.DefineVar(conversion::fromStringToWString("z"), &z);

--- a/src/meshlabplugins/filter_func/filter_func.cpp
+++ b/src/meshlabplugins/filter_func/filter_func.cpp
@@ -22,8 +22,8 @@
  ****************************************************************************/
 
 #include "filter_func.h"
+#include <random>
 #include <vcg/complex/algorithms/create/platonic.h>
-
 #include <vcg/complex/algorithms/create/marching_cubes.h>
 #include <vcg/complex/algorithms/create/mc_trivial_walker.h>
 

--- a/src/meshlabplugins/filter_func/filter_func.cpp
+++ b/src/meshlabplugins/filter_func/filter_func.cpp
@@ -38,7 +38,7 @@ std::default_random_engine rndEngine(randomDev());
 //Function to generate a random double number in [0..1) interval
 double ML_Rnd() { return std::generate_canonical<double, 24>(rndEngine); }
 //Function to generate a random integer number in [0..a) interval
-double ML_RandInt(const double a) { return std::floor(a*MyRnd()); }
+double ML_RandInt(const double a) { return std::floor(a*ML_Rnd()); }
 
 //Add rnd() and randint() custom functions to a mu::Parser
 void setCustomFunctions(mu::Parser& p)


### PR DESCRIPTION
Add two functions to muParse to generate random numbers

* rnd() will generate a random double value in [0.0 .. 1.0) interval
* randInt(n) will generate a random integer value in [0 .. n) interval

Those functions may be used to generate noise custom noise algorithm that can be aplied to geometry, colors, normals, etc. or select a random number of vertex/faces than can be erased/processed in posterior filters.