### PR TITLE
fix bug for PercentageValue

### DIFF
--- a/src/common/filter_history/filter.cpp
+++ b/src/common/filter_history/filter.cpp
@@ -126,7 +126,7 @@ std::string Filter::pyMeshLabCall(std::string meshSetName) const
 				else if (p.isOfType<RichPercentage>()) {
 					const RichPercentage& rp = dynamic_cast<const RichPercentage&>(p);
 					float per = (p.value().getFloat() / (rp.max - rp.min) ) * 100;
-					call += "pymeshlab.PercentageValue(" + std::to_string(per) + ")";
+					call += "pymeshlab.Percentage(" + std::to_string(per) + ")";
 				}
 			}
 		}


### PR DESCRIPTION
I am using the meshlab GUI software to generate the pymeshlab filter script. However, I got an error when pasting the code to a Python file. For example:  
```txt
>>> ms.generate_sampling_clustered_vertex(threshold = pymeshlab.PercentageValue(1.100005))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'pymeshlab' has no attribute 'PercentageValue'
```

This PR should fix the bug above.