### PR TITLE
Update meshlab.desktop to request Descrete GPU

### DIFF
--- a/resources/linux/meshlab.desktop
+++ b/resources/linux/meshlab.desktop
@@ -10,3 +10,4 @@ Terminal=false
 MimeType=model/mesh;application/x-3ds;image/x-3ds;model/x-ply;application/sla;model/x-quad-object;model/x-geomview-off;application/x-cyclone-ptx;application/x-vmi;application/x-bre;model/vnd.collada+xml;model/openctm;application/x-expe-binary;application/x-expe-ascii;application/x-xyz;application/x-gts;chemical/x-pdb;application/x-tri;application/x-asc;model/x3d+xml;model/x3d+vrml;model/vrml;model/u3d;model/idtf;
 Categories=Graphics;3DGraphics;Viewer;Qt;
 Name[en_US]=MeshLab
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
Note that this option is expressed as Non-Default. This flag was added in the v1.4 of the desktop entry spec.
