### PR TITLE
Use updateDataMask in gltf loader for vertcolor and wedgetexcoord

### DIFF
--- a/src/meshlabplugins/io_gltf/gltf_loader.cpp
+++ b/src/meshlabplugins/io_gltf/gltf_loader.cpp
@@ -430,6 +430,7 @@ void loadMeshPrimitive(
 	res = loadAttribute(m, ivp, model, p, COLOR_0);
 	if (res) {
 		mask |= vcg::tri::io::Mask::IOM_VERTCOLOR;
+		m.updateDataMask(MeshModel::MM_VERTCOLOR);
 	}
 	progress.increment();
 	if (cb)
@@ -437,6 +438,7 @@ void loadMeshPrimitive(
 	res = loadAttribute(m, ivp, model, p, TEXCOORD_0, textureImg);
 	if (res) {
 		mask |= vcg::tri::io::Mask::IOM_WEDGTEXCOORD;
+		m.updateDataMask(MeshModel::MM_WEDGTEXCOORD);
 	}
 	progress.increment();
 


### PR DESCRIPTION
This PR addresses issue #1464 where vertex colors are not loaded properly from gltf files. 

I tested the change on Windows 10 and Ubuntu 22.04 with some gltf files available here:

https://github.com/KhronosGroup/glTF-Sample-Assets
