### PR TITLE
Fix division overflow in "Trivial per triangle" for 0-area faces

### DIFF
--- a/src/meshlabplugins/filter_texture/filter_texture.cpp
+++ b/src/meshlabplugins/filter_texture/filter_texture.cpp
@@ -504,12 +504,17 @@ std::map<std::string, QVariant> FilterTexturePlugin::applyFilter(
 			}
 			
 			// Creates buckets containing each halfening level triangles (a histogram)
-			int    buckSize = (int)ceil(log_2(maxArea/minArea) + DBL_EPSILON);
+			// Using the logarithm law
+			//       log_2(maxArea / minArea)
+			//     = log_2(maxArea) - log_2(minArea)
+			// but the latter does not overflow the division if `minArea = DBL_MIN`
+			// as set above for `area == 0`.
+			int    buckSize = (int)ceil(log_2(maxArea) - log_2(minArea) + DBL_EPSILON);
 			std::vector<std::vector<uint> > buckets(buckSize);
 			for (uint i=0; i<areas.size(); ++i)
 				if (areas[i]>=0)
 				{
-					int slot = (int)ceil(log_2(maxArea/areas[i]) + DBL_EPSILON) - 1;
+					int slot = (int)ceil(log_2(maxArea) - log_2(areas[i]) + DBL_EPSILON) - 1;
 					assert(slot < buckSize && slot >= 0);
 					buckets[slot].push_back(i);
 				}


### PR DESCRIPTION
Fixes #1557.

I didn't test it on `main` because only `devel` builds on my Ubuntu 24.04, but I tested it successfully on `devel` with the git cherry-pick https://github.com/cnr-isti-vclab/meshlab/commit/850ae03ab6b076ed44f39e030e763114308ef355.

---

Fix sponsored by my startup [Benaco](https://benaco.com), which makes photo-realistic 3D tours from laser scan data.