### PR TITLE
Ubuntu 20.04 runner closed

### DIFF
--- a/.github/workflows/BuildMeshLab.yml
+++ b/.github/workflows/BuildMeshLab.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         precision: [single_precision, double_precision]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/BuildMeshLab.yml
+++ b/.github/workflows/BuildMeshLab.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         precision: [single_precision, double_precision]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
         precision: [single_precision, double_precision]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/CreateRelease.yml
+++ b/.github/workflows/CreateRelease.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-13', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04', 'ubuntu-24.04-arm', 'macos-13', 'macos-latest', 'windows-latest']
         precision: [single_precision, double_precision]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the supported operating systems in the GitHub Actions workflows for building and creating releases for the project. The most important changes include adding support for `ubuntu-24.04-arm` and updating the Ubuntu version to `24.04`.

Updates to GitHub Actions workflows:

* [`.github/workflows/BuildMeshLab.yml`](diffhunk://#diff-0a15885d6d391fe118a857a112a817de456b73b5e72a1f66f478a3c3e9090492L19-R19): Added `ubuntu-24.04-arm` and updated Ubuntu version to `24.04` in the matrix configuration.
* [`.github/workflows/CreateRelease.yml`](diffhunk://#diff-88642cd6de1704614ec1cefa96fe09afdd85fb3b076cff8ebfbd2f5089cf9c2aL37-R37): Added `ubuntu-24.04-arm` and updated Ubuntu version to `24.04` in the matrix configuration.