### PR TITLE
fix build with latest microsoft stl

### DIFF
--- a/src/common/GLLogStream.h
+++ b/src/common/GLLogStream.h
@@ -32,13 +32,13 @@
 #include <QString>
 #include <QObject>
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef ML_EXPORT_SYMBOLS
 #define ML_DLL_EXPORT Q_DECL_EXPORT
 #else
 #define ML_DLL_EXPORT Q_DECL_IMPORT
 #endif
-#else //WIN32
+#else //_WIN32
 #define ML_DLL_EXPORT
 #endif
 


### PR DESCRIPTION
`WIN32` was usually defined in minwindef.h, which is no longer
included by most MSVC STL headers.

_WIN32 is a predefined MACRO, it should fit here.  

error:
```
mainwindow_RunTime.cpp.obj : error LNK2001: unresolved external symbol "public: static struct QMetaObject const GLLogStream::staticMetaObject" (?staticMetaObject@GLLogStream@@2UQMetaObject@@B)
```

build environment:
```
compiler: cl 19.44.35214 for x64
generator: Ninja Multi-Config
CMAKE_CXX_FLAGS: /utf-8 /EHsc
```

