### PR TITLE
Update CMake modules, name, mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,89 @@
+
+# need name in second half because sometimes this email has different names on it (see below)
+Paolo Cignoni <paolo.cignoni@isti.cnr.it> Paolo Cignoni cignoni <paolo.cignoni@isti.cnr.it>
+Paolo Cignoni <paolo.cignoni@isti.cnr.it> Paolo Cignoni <cignoni@isti.cnr.it>
+Paolo Cignoni <paolo.cignoni@isti.cnr.it> cignoni <cignoni@isti.cnr.it>
+
+# not sure the real email of these people or why their commits use Paolo's email
+# Some appear to be past PhD students or visiting scholars at VCG.
+Andrea Bernabei <paolo.cignoni@isti.cnr.it> Andrea Bernabei bernabei <paolo.cignoni@isti.cnr.it>
+Gregorio Palmas <paolo.cignoni@isti.cnr.it> Gregorio Palmas palmas <paolo.cignoni@isti.cnr.it>
+Luca Benedetti <paolo.cignoni@isti.cnr.it> Luca Benedetti benedetti <paolo.cignoni@isti.cnr.it>
+Michele Sottile <paolo.cignoni@isti.cnr.it> Michele Sottile sottile <paolo.cignoni@isti.cnr.it>
+Ricardo Marroquim <paolo.cignoni@isti.cnr.it> Ricardo Marroquim marroquim <paolo.cignoni@isti.cnr.it>
+Rosario Aiello <paolo.cignoni@isti.cnr.it> Rosario Aiello aiello <paolo.cignoni@isti.cnr.it>
+Stefano Marras <paolo.cignoni@isti.cnr.it> Stefano Marras marras <paolo.cignoni@isti.cnr.it>
+
+# Former visiting scholar at VCG, Eigen maintainer
+Gael Guennebaud <gael.guennebaud@inria.fr> Gael Guennebaud guennebaud <paolo.cignoni@isti.cnr.it>
+
+# More typical entries follow, to unify contributions amd correct names/emails
+
+Alberto Mardegan <alberto.mardegan@canonical.com>
+Alberto Mardegan <alberto.mardegan@canonical.com> <mardy@users.sourceforge.net>
+
+Alessandro Muntoni <muntoni.alessandro@gmail.com>
+Alessandro Muntoni <muntoni.alessandro@gmail.com> <alemuntoni@users.noreply.github.com>
+
+Andrea Baldacci <andrea.baldacci@isti.cnr.it>
+
+David Boening <davidboening@yahoo.it>
+
+Fabio Ganovelli <fabio.ganovelli@isti.cnr.it>
+Fabio Ganovelli <fabio.ganovelli@isti.cnr.it> <fabio.ganovelli@gmail.com>
+
+Federico Ponchio <federico.ponchio@isti.cnr.it>
+Federico Ponchio <federico.ponchio@isti.cnr.it> <ponchio@gmail.com>
+
+Gianpaolo Palma <gianpaolo.palma@isti.cnr.it>
+
+Giovanni Pintore <giannipint@gmail.com>
+
+Giorgio Marcias <giorgio.marcias@isti.cnr.it>
+Giorgio Marcias <giorgio.marcias@isti.cnr.it> <marcias.giorgio@gmail.com>
+
+Guido Ranzuglia <guido.ranzuglia@isti.cnr.it>
+
+JM Espadero <josemiguel.espadero@urjc.es>
+
+Lex van der Sluijs <lvandersluijs@ptc.com>
+Lex van der Sluijs <lvandersluijs@ptc.com> <78106735+ptc-lexvandersluijs@users.noreply.github.com>
+
+Luca Franceschi <l.franceschi5@studenti.unipi.it>
+
+Lucas Palomo <lucas.palomo@t-online.de>
+
+Luigi Malomo <luigi.malomo@isti.cnr.it>
+Luigi Malomo <luigi.malomo@isti.cnr.it> <malomo.luigi@gmail.com>
+Luigi Malomo <luigi.malomo@isti.cnr.it> <malomo@users.noreply.github.com>
+
+Manuele Sabbadin <manuele.sabbadin@isti.cnr.it>
+
+Marco Callieri <marco.callieri@isti.cnr.it>
+Marco Callieri <marco.callieri@isti.cnr.it> <callieri@isti.cnr.it>
+
+Marco Di Benedetto <marco.dibenedetto@isti.cnr.it>
+
+Massimiliano Corsini <massimiliano.corsini@isti.cnr.it>
+
+Matteo Dellepiane <matteo.dellepiane@isti.cnr.it>
+
+Michael Savich <savichmichael@gmail.com>
+
+Michele Morisco <michele.morisco94@gmail.com>
+Michele Morisco <michele.morisco94@gmail.com> <43170306+michisco@users.noreply.github.com>
+
+Nico Pietroni <nico.pietroni@isti.cnr.it>
+
+Nicolas Mellado <nmellado0@gmail.com>
+
+Rylie Pavlik <rylie.pavlik@collabora.com>
+Rylie Pavlik <rylie.pavlik@collabora.com> <ryan.pavlik@collabora.com>
+Rylie Pavlik <rylie@ryliepavlik.com>
+Rylie Pavlik <rylie@ryliepavlik.com> <ryan@ryanpavlik.com>
+
+Steve Demlow <demlow@gmail.com>
+Steve Demlow <demlow@gmail.com> <steve.demlow@mmm.com>
+
+gabryon99 <leleattolo99@gmail.com>
+gabryon99 <leleattolo99@gmail.com> <pappalardo@ntop.org>

--- a/docs/man/meshlabserver.1
+++ b/docs/man/meshlabserver.1
@@ -1,4 +1,4 @@
-.\" Written by Ryan Pavlik <ryan@ryanpavlik.com> in mandoc format,
+.\" Written by Rylie Pavlik <rylie@ryliepavlik.com> in mandoc format,
 .\" based on the original help output from the meshlabserver program.
 .Dd March 05, 2020
 .Dt MESHLABSERVER 1

--- a/src/cmake/FindGMP.cmake
+++ b/src/cmake/FindGMP.cmake
@@ -13,7 +13,7 @@
 #  GMP_VERSION - GMP version
 #
 # Copyright (c) 2016 Jack Poulson, <jack.poulson@gmail.com>
-# Copyright (c) 2019 Collabora, Ltd. (Ryan Pavlik <ryan.pavlik@collabora.com>)
+# Copyright (c) 2019 Collabora, Ltd. (Rylie Pavlik <rylie.pavlik@collabora.com>)
 # Redistribution and use is allowed according to the terms of the BSD license.
 
 find_path(

--- a/src/cmake/FindLib3ds.cmake
+++ b/src/cmake/FindLib3ds.cmake
@@ -5,9 +5,10 @@
 #  LIB3DS_FOUND - True if lib3ds was found.
 #
 # Original Author:
-# 2019 Ryan Pavlik <ryan.pavlik@collabora.com> <ryan.pavlik@gmail.com>
+# 2019 Rylie Pavlik <rylie.pavlik@collabora.com> <rylie@ryliepavlik.com>
 #
 # Copyright 2019, Collabora, Ltd.
+#
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -27,7 +28,7 @@ find_library(
     PATHS "${LIB3DS_ROOT_DIR}")
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LIB3DS DEFAULT_MSG LIB3DS_INCLUDE_DIR
+find_package_handle_standard_args(Lib3ds DEFAULT_MSG LIB3DS_INCLUDE_DIR
                                   LIB3DS_LIBRARY)
 
 if(LIB3DS_FOUND)

--- a/src/cmake/FindOpenCTM.cmake
+++ b/src/cmake/FindOpenCTM.cmake
@@ -5,9 +5,10 @@
 #  OPENCTM_FOUND - True if OpenCTM was found.
 #
 # Original Author:
-# 2019 Ryan Pavlik <ryan.pavlik@collabora.com> <ryan.pavlik@gmail.com>
+# 2019 Rylie Pavlik <rylie.pavlik@collabora.com> <rylie@ryliepavlik.com>
 #
 # Copyright 2019, Collabora, Ltd.
+#
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/src/cmake/Findmuparser.cmake
+++ b/src/cmake/Findmuparser.cmake
@@ -2,12 +2,13 @@
 # Find the muparser C++ math expression parser library
 #
 # muparser::muparser - Imported target to use
-# MUPARSER_FOUND - True if muparser # was found.
+# MUPARSER_FOUND - True if muparser was found.
 #
-# Original Author: 2019 Ryan Pavlik <ryan.pavlik@collabora.com>
-# <ryan.pavlik@gmail.com>
+# Original Author: 2019 Rylie Pavlik <rylie.pavlik@collabora.com>
+# <rylie@ryliepavlik.com>
 #
 # Copyright 2019, Collabora, Ltd.
+#
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
A few small cleanup items in here:

- I updated the CMake modules that come from my large repo to match the upstream.
- I fixed my name/email in a few other files.
- I added a `.mailmap` file - to fix my name/email in the commit history, but also to unify/normalize other committer identities. `git shortlog -s -e` went from 120 lines down to 93  when applying this mailmap file to combine duplicates, etc. There are a few folks who committed with Paolo's email that I don't know a better email for them right now, they are marked accordingly in the file.