### PR TITLE
Github Action to auto push new releases to Winget package registry

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -1,11 +1,7 @@
 name: Publish release to WinGet
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "Specific tag name"
-        required: false
-        type: string
+  release:
+    types: [released]
 
 jobs:
   publish:
@@ -14,7 +10,7 @@ jobs:
       - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: CNRISTI.MeshLab
-          installers-regex: '${{ inputs.tag_name }}-windows_x86_64.exe'
-          version: ${{ inputs.tag_name }}
+          installers-regex: '${{ github.event.release.tag_name }}-windows_x86_64.exe'
+          version: ${{ github.event.release.tag_name }}
           token: ${{ secrets.WINGET_ACC_TOKEN }}
           fork-user: alemuntoni


### PR DESCRIPTION
Note, at the moment, there are unofficial bots maintaining the winget package given github releases see example PR https://github.com/microsoft/winget-pkgs/pull/276316

It would be great to use a github action in this repo to push every new github release to the winget package registry `CNRISTI.MeshLab` . 

This PR uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) (which uses Komac). It requires a `Classic Github Personal Access Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

> Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.
