### PR TITLE
Add global parameter system for edit plugins, optional CTRL invert selection

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -161,6 +161,7 @@ set(SOURCES
 	plugins/containers/render_plugin_container.cpp
 	plugins/interfaces/meshlab_plugin_logger.cpp
 	plugins/interfaces/decorate_plugin.cpp
+	plugins/interfaces/edit_plugin.cpp
 	plugins/interfaces/filter_plugin.cpp
 	plugins/interfaces/io_plugin.cpp
 	plugins/action_searcher.cpp

--- a/src/common/plugins/interfaces/edit_plugin.cpp
+++ b/src/common/plugins/interfaces/edit_plugin.cpp
@@ -1,0 +1,5 @@
+#include "edit_plugin.h"
+
+void EditPlugin::initGlobalParameterList(RichParameterList& globalparam)
+{
+}

--- a/src/common/plugins/interfaces/edit_plugin.h
+++ b/src/common/plugins/interfaces/edit_plugin.h
@@ -108,6 +108,8 @@ public:
 	EditPlugin() {}
 	virtual ~EditPlugin() {}
 
+	virtual void initGlobalParameterList(RichParameterList& defaultGlobalParamSet);
+
 	//gets a list of actions available from this plugin
 	virtual std::list<QAction *> actions() const {return actionList;};
 
@@ -117,8 +119,14 @@ public:
 	//get the description for the given action
 	virtual QString getEditToolDescription(const QAction *) = 0;
 
+	void setCurrentGlobalParamSet(RichParameterList* cgp)
+	{
+		currentGlobalParamSet = cgp;
+	}
+
 protected:
 	std::list<QAction*> actionList;
+	RichParameterList* currentGlobalParamSet;
 };
 
 #define EDIT_PLUGIN_IID  "vcg.meshlab.EditPlugin/1.0"

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -113,6 +113,7 @@ public:
 	static bool QCallBack(const int pos, const char * str);
 	//const QString appName() const {return tr("MeshLab v")+appVer(); }
 	//const QString appVer() const {return tr("1.3.2"); }
+	RichParameterList& getCurrentParameterList();
 	MainWindowSetting mwsettings;
 public slots:
 	// callback function to execute a filter
@@ -531,6 +532,9 @@ private:
 	static QString getDecoratedFileName(const QString& name);
 
 	MultiViewer_Container* _currviewcontainer;
+
+Q_SIGNALS:
+	void customSettingsChanged(const RichParameterList &rpl);
 };
 
 /// Event filter that is installed to intercept the open events sent directly by the Operative System

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -922,6 +922,12 @@ void MainWindow::loadDefaultSettingsFromPlugins()
 		}
 	}
 
+	//edit settings
+	for (EditPlugin* ep : PM.editPluginFactoryIterator()) {
+		ep->initGlobalParameterList(defaultGlobalParams);
+		ep->setCurrentGlobalParamSet(&currentGlobalParams);
+	}
+
 	//io settings
 	for (IOPlugin* iop : PM.ioPluginIterator()){
 		for (const FileFormat& ff : iop->importFormats()) {

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -104,6 +104,11 @@ void MainWindow::updateCustomSettings()
 {
 	mwsettings.updateGlobalParameterList(currentGlobalParams);
 	emit dispatchCustomSettings(currentGlobalParams);
+
+}
+RichParameterList& MainWindow::getCurrentParameterList()
+{
+	return currentGlobalParams;
 }
 
 void MainWindow::updateWindowMenu()
@@ -2196,6 +2201,15 @@ void MainWindow::reloadAllMesh()
 {
 	// Discards changes and reloads current file
 	// save current file name
+	QMessageBox::StandardButton reply;
+	reply = QMessageBox::question(
+		this,
+		tr("You are reloading all mesh!"),
+		tr("Are You sure to Reload?"),
+		QMessageBox::Yes | QMessageBox::No);
+	if (reply == QMessageBox::No) {
+		return;
+	}
 	qb->show();
 	QElapsedTimer t;
 	t.start();
@@ -2244,6 +2258,14 @@ void MainWindow::reload()
 		return;
 	// Discards changes and reloads current file
 	// save current file name
+	QMessageBox::StandardButton reply;
+	reply = QMessageBox::question(this,
+		tr("You are reloading the current mesh"),
+		tr("Are you sure to reload?"),
+		QMessageBox::Yes | QMessageBox::No);
+	if (reply == QMessageBox::No) {
+		return;
+	}
 	qb->show();
 
 	QString fileName = meshDoc()->mm()->fullName();

--- a/src/meshlabplugins/edit_align/edit_align_factory.h
+++ b/src/meshlabplugins/edit_align/edit_align_factory.h
@@ -38,6 +38,11 @@ public:
 	EditAlignFactory();
 	virtual ~EditAlignFactory() { delete editAlign; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 	
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_manipulators/edit_manipulators_factory.h
+++ b/src/meshlabplugins/edit_manipulators/edit_manipulators_factory.h
@@ -38,6 +38,11 @@ public:
 	EditManipulatorsFactory();
 	virtual ~EditManipulatorsFactory() { delete editManipulators; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_measure/edit_measure_factory.h
+++ b/src/meshlabplugins/edit_measure/edit_measure_factory.h
@@ -38,6 +38,11 @@ public:
 	EditMeasureFactory();
 	virtual ~EditMeasureFactory() { delete editMeasure; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_mutualcorrs/edit_mutualcorrs_factory.h
+++ b/src/meshlabplugins/edit_mutualcorrs/edit_mutualcorrs_factory.h
@@ -37,6 +37,11 @@ public:
 	EditMutualCorrsFactory();
 	virtual ~EditMutualCorrsFactory() { delete editMutualCorrs; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_paint/edit_paint_factory.h
+++ b/src/meshlabplugins/edit_paint/edit_paint_factory.h
@@ -38,6 +38,11 @@ public:
 	EditPaintFactory();
 	virtual ~EditPaintFactory() { delete editPaint; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_pickpoints/edit_pickpoints_factory.h
+++ b/src/meshlabplugins/edit_pickpoints/edit_pickpoints_factory.h
@@ -38,6 +38,11 @@ public:
 	EditPickPointsFactory();
 	virtual ~EditPickPointsFactory() { delete editPickPoints; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_point/edit_point_factory.h
+++ b/src/meshlabplugins/edit_point/edit_point_factory.h
@@ -38,6 +38,11 @@ public:
 	PointEditFactory();
 	virtual ~PointEditFactory() { delete editPoint; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_quality/edit_quality_factory.h
+++ b/src/meshlabplugins/edit_quality/edit_quality_factory.h
@@ -38,6 +38,11 @@ public:
 	QualityMapperFactory();
 	virtual ~QualityMapperFactory() { delete editQuality; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_referencing/edit_referencing_factory.h
+++ b/src/meshlabplugins/edit_referencing/edit_referencing_factory.h
@@ -37,6 +37,11 @@ public:
 	EditReferencingFactory();
 	virtual ~EditReferencingFactory() { delete editReferencing; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action

--- a/src/meshlabplugins/edit_sample/edit_sample_factory.h
+++ b/src/meshlabplugins/edit_sample/edit_sample_factory.h
@@ -38,6 +38,11 @@ public:
 	SampleEditFactory();
 	virtual ~SampleEditFactory() { delete editSample; }
 
+	void initGlobalParameterList(RichParameterList& /*paramList*/)
+	{
+		// No global parameters needed for this plugin
+	}
+
 	//returns the name of the plugin
 	virtual QString pluginName() const;
 

--- a/src/meshlabplugins/edit_select/edit_select.h
+++ b/src/meshlabplugins/edit_select/edit_select.h
@@ -24,29 +24,30 @@
 #define EDITPLUGIN_H
 
 #include <common/plugins/interfaces/edit_plugin.h>
+#include <QObject>
 
 class EditSelectPlugin : public QObject, public EditTool
 {
 	Q_OBJECT
 
-
 public:
+
 	enum { SELECT_FACE_MODE, SELECT_VERT_MODE, SELECT_CONN_MODE, SELECT_AREA_MODE };
 
-	EditSelectPlugin(int _ConnectedMode);
-
+	EditSelectPlugin(RichParameterList* cgp, int _ConnectedMode);
 	virtual ~EditSelectPlugin() {}
-
 	static QString info();
 	void suggestedRenderingData(MeshModel & m, MLRenderingData& dt);
 	bool startEdit(MeshModel &/*m*/, GLArea * /*parent*/, MLSceneGLSharedDataContext* /*cont*/);
 	void endEdit(MeshModel &/*m*/, GLArea * /*parent*/, MLSceneGLSharedDataContext* /*cont*/) {}
 	void decorate(MeshModel &/*m*/, GLArea * /*parent*/);
-	void mousePressEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *);
-	void mouseMoveEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *);
-	void mouseReleaseEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *);
-	void keyReleaseEvent(QKeyEvent *, MeshModel &/*m*/, GLArea *);
-	void keyPressEvent(QKeyEvent *, MeshModel &/*m*/, GLArea *);
+	void mousePressEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *gla);
+	void mouseMoveEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *gla);
+	void mouseReleaseEvent(QMouseEvent *event, MeshModel &/*m*/, GLArea *gla);
+	virtual void keyReleaseEvent(QKeyEvent *, MeshModel &m, GLArea *gla);
+	void keyPressEvent(QKeyEvent *, MeshModel &m, GLArea *gla);
+	EditTool* getEditTool(const QAction *action);
+	bool keyReleaseEventFilter(QObject *obj, QEvent *event);
 
 	vcg::Point2f start;
 	vcg::Point2f cur;
@@ -71,12 +72,17 @@ signals:
 	void setDecorator(QString, bool);
 
 private:
+	MeshModel *m_ref;
+	GLArea *gla_ref;
+	RichParameterList* currentGlobalParamSet;
+	bool ctrlState;
 	typedef enum { SMAdd, SMClear, SMSub } ComposingSelMode; // How the selection are composed
 	ComposingSelMode composingSelMode;
 	bool selectFrontFlag;
 	void DrawXORRect(GLArea * gla, bool doubleDraw);
 	void DrawXORPolyLine(GLArea * gla);
 	void doSelection(MeshModel &m, GLArea *gla, int mode);
+
 };
 
 #endif

--- a/src/meshlabplugins/edit_select/edit_select_factory.cpp
+++ b/src/meshlabplugins/edit_select/edit_select_factory.cpp
@@ -23,6 +23,7 @@
 
 #include "edit_select_factory.h"
 #include "edit_select.h"
+#include "common/parameters/rich_parameter_list.h"
 
 EditSelectFactory::EditSelectFactory()
 {
@@ -37,7 +38,10 @@ EditSelectFactory::EditSelectFactory()
 	actionList.push_back(editSelectArea);
 	
 	foreach(QAction *editAction, actionList)
-		editAction->setCheckable(true); 	
+		editAction->setCheckable(true);
+}
+void EditSelectFactory::initGlobalParameterList(RichParameterList& defaultGlobalParamSet) {
+	defaultGlobalParamSet.addParam(RichBool(InvertCtrlBehavior(), true,"Inverting the behavior of the CTRL modifier on edit selec rectangle tools",""));
 }
 
 QString EditSelectFactory::pluginName() const
@@ -48,17 +52,21 @@ QString EditSelectFactory::pluginName() const
 //get the edit tool for the given action
 EditTool* EditSelectFactory::getEditTool(const QAction *action)
 {
+	EditSelectPlugin* result = nullptr;
 	if(action == editSelect)
-		return new EditSelectPlugin(EditSelectPlugin::SELECT_FACE_MODE);
+		result = new EditSelectPlugin(currentGlobalParamSet,EditSelectPlugin::SELECT_FACE_MODE);
 	else if(action == editSelectConnected)
-		return new EditSelectPlugin(EditSelectPlugin::SELECT_CONN_MODE);
+		result = new EditSelectPlugin(currentGlobalParamSet,EditSelectPlugin::SELECT_CONN_MODE);
 	else if(action == editSelectVert)
-		return new EditSelectPlugin(EditSelectPlugin::SELECT_VERT_MODE);
+		result = new EditSelectPlugin(currentGlobalParamSet,EditSelectPlugin::SELECT_VERT_MODE);
 	else if (action == editSelectArea)
-		return new EditSelectPlugin(EditSelectPlugin::SELECT_AREA_MODE);
+		result = new EditSelectPlugin(currentGlobalParamSet,EditSelectPlugin::SELECT_AREA_MODE);
 
-	assert(0); //should never be asked for an action that isn't here
-	return nullptr;
+	if (result == nullptr) {
+		assert(0);
+	}
+
+	return (EditTool*)result;
 }
 
 QString EditSelectFactory::getEditToolDescription(const QAction * /*a*/)

--- a/src/meshlabplugins/edit_select/edit_select_factory.cpp
+++ b/src/meshlabplugins/edit_select/edit_select_factory.cpp
@@ -41,7 +41,7 @@ EditSelectFactory::EditSelectFactory()
 		editAction->setCheckable(true);
 }
 void EditSelectFactory::initGlobalParameterList(RichParameterList& defaultGlobalParamSet) {
-	defaultGlobalParamSet.addParam(RichBool(InvertCtrlBehavior(), true,"Inverting the behavior of the CTRL modifier on edit selec rectangle tools",""));
+	defaultGlobalParamSet.addParam(RichBool(InvertCtrlBehavior(), false,"Invert the behavior of the CTRL modifier on edit selection rectangle tools",""));
 }
 
 QString EditSelectFactory::pluginName() const

--- a/src/meshlabplugins/edit_select/edit_select_factory.h
+++ b/src/meshlabplugins/edit_select/edit_select_factory.h
@@ -26,6 +26,7 @@
 #define EditSelectFactoryPLUGIN_H
 
 #include <common/plugins/interfaces/edit_plugin.h>
+#include "common/parameters/rich_parameter_list.h"
 
 class EditSelectFactory : public QObject, public EditPlugin
 {
@@ -37,6 +38,8 @@ public:
 	EditSelectFactory();
 	virtual ~EditSelectFactory() { delete editSelect; }
 
+	virtual void initGlobalParameterList(RichParameterList& defaultGlobalParamSet);
+
 	virtual QString pluginName() const;
 
 	//get the edit tool for the given action
@@ -45,7 +48,13 @@ public:
 	//get the description for the given action
 	virtual QString getEditToolDescription(const QAction*);
 
+	inline QString InvertCtrlBehavior() const { return  "MeshLab::Editors::InvertCTRLBehavior" ; }
+
+signals:
+	void setDecorator(QString, bool);
+
 private:
+	bool ctrlState;
 	QAction *editSelect;
 	QAction *editSelectVert;
 	QAction *editSelectConnected;


### PR DESCRIPTION
## Summary
- **Global Parameter System for Edit Plugins**: `EditPlugin` base class now supports `initGlobalParameterList` and `setCurrentGlobalParamSet` for persistent per-plugin settings saved across sessions
- **Optional CTRL Selection Invert**: Adds an opt-in `Invert CTRL Behavior` setting (default **OFF**) — when enabled, drag adds to selection and CTRL+drag replaces. Default MeshLab behavior is preserved
- **Reload Confirmation Dialogs**: Added confirmation prompts before `Reload` and `Reload All` to prevent accidental loss of work

## Details
The global parameter system extends the existing `EditPlugin` interface so that any edit plugin can register settings that persist in MeshLab's settings system. The CTRL invert feature uses this system to expose its toggle.

All existing edit plugin factory headers are updated to conform to the new interface (trivial changes — just adding the required virtual method stubs).

**Default behavior is unchanged** — the CTRL invert is opt-in only.

## Test plan
- [ ] Verify default selection behavior (drag = replace, CTRL+drag = add) is unchanged
- [ ] Enable "Invert CTRL Behavior" in settings, verify inverted mode works
- [ ] Verify setting persists across sessions
- [ ] Verify Reload / Reload All show confirmation dialogs
- [ ] Build on Windows, Linux, macOS

> **Note**: This is PR 1 of 3 (split from #1638). PRs 2 (Lasso Cut) and 3 (Undo/Redo) build on this.