### PR TITLE
Closes issue #400 ; adds camera bob mode to aid depth perception

### DIFF
--- a/src/meshlab/glarea.cpp
+++ b/src/meshlab/glarea.cpp
@@ -36,6 +36,7 @@
 #include <QPainterPath>
 #include <QElapsedTimer>
 #include <QApplication>
+#include <cmath>
 
 #include <wrap/gl/picking.h>
 #include <wrap/qt/trackball.h>
@@ -73,6 +74,7 @@ GLArea::GLArea(QWidget *parent, MultiViewer_Container *mvcont, RichParameterList
     activeDefaultTrackball=true;
     infoAreaVisible = true;
     trackBallVisible = glas.startupShowTrackball;
+    stereopsisBobEnabled = false;
     currentShader = NULL;
     lastFilterRef = NULL;
     //lastEditRef = NULL;
@@ -124,6 +126,8 @@ GLArea::GLArea(QWidget *parent, MultiViewer_Container *mvcont, RichParameterList
     }else{
         qDebug("The parent of the GLArea parent is not a pointer to the meshlab MainWindow.");
     }
+    stereopsisBobTimer.setInterval(stereopsisBobFrameIntervalMs());
+    connect(&stereopsisBobTimer, SIGNAL(timeout()), this, SLOT(advanceStereopsisBob()));
 	lastloadedraster = -1;
 }
 
@@ -1634,7 +1638,19 @@ void GLArea::setView()
 
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
-    gluLookAt(0, 0, cameraDist, 0, 0, 0, 0, 1, 0);
+    Point3f eye(0.0f, 0.0f, cameraDist);
+    if (shouldStereopsisBob()) {
+        if (!stereopsisBobClock.isValid())
+            stereopsisBobClock.start();
+        if (!stereopsisBobTimer.isActive())
+            stereopsisBobTimer.start();
+        eye = stereopsisBobEye(cameraDist);
+    }
+    else if (stereopsisBobTimer.isActive()) {
+        stereopsisBobTimer.stop();
+        stereopsisBobClock.invalidate();
+    }
+    gluLookAt(eye[0], eye[1], eye[2], 0, 0, 0, 0, 1, 0);
 }
 
 void GLArea::setTiledView(GLdouble fovY, float viewRatio, float fAspect, GLdouble zNear, GLdouble zFar,  float /*cameraDist*/)
@@ -1686,6 +1702,47 @@ void GLArea::updateFps(float deltaTime)
     lastTime=deltaTime;
 }
 
+Point3f GLArea::stereopsisBobEye(float cameraDist) const
+{
+    if (stereopsisBobAmplitudeDegrees() <= 0.0f || stereopsisBobFrequencyHz() <= 0.0f)
+        return Point3f(0.0f, 0.0f, cameraDist);
+
+    const float elapsedSeconds = stereopsisBobClock.elapsed() / 1000.0f;
+    const float phase = elapsedSeconds * math::ToRad(360.0f) * stereopsisBobFrequencyHz();
+    const float radius = cameraDist * std::tan(math::ToRad(stereopsisBobAmplitudeDegrees()));
+    return Point3f(radius * std::cos(phase), radius * std::sin(phase), cameraDist);
+}
+
+bool GLArea::shouldStereopsisBob() const
+{
+    return stereopsisBobEnabled && stereopsisBobAmplitudeDegrees() > 0.0f && stereopsisBobFrequencyHz() > 0.0f;
+}
+
+void GLArea::setStereopsisBobEnabled(bool enabled)
+{
+    if (stereopsisBobEnabled == enabled)
+        return;
+
+    stereopsisBobEnabled = enabled;
+    if (stereopsisBobEnabled && stereopsisBobAmplitudeDegrees() > 0.0f && stereopsisBobFrequencyHz() > 0.0f) {
+        stereopsisBobClock.start();
+        stereopsisBobTimer.start();
+    }
+    else {
+        stereopsisBobTimer.stop();
+        stereopsisBobClock.invalidate();
+    }
+    update();
+}
+
+void GLArea::advanceStereopsisBob()
+{
+    if (shouldStereopsisBob())
+        update();
+    else if (stereopsisBobTimer.isActive())
+        stereopsisBobTimer.stop();
+}
+
 void GLArea::resetTrackBall()
 {
     makeCurrent();
@@ -1703,6 +1760,8 @@ void GLArea::resetTrackBall()
 void GLArea::hideEvent(QHideEvent * /*event*/)
 {
     trackball.current_button=0;
+    if (stereopsisBobTimer.isActive())
+        stereopsisBobTimer.stop();
 }
 
 void GLArea::sendViewPos(QString name)
@@ -2518,4 +2577,3 @@ MainWindow * GLArea::mw()
     }
     return qobject_cast<MainWindow *>(curParent);
 }
-

--- a/src/meshlab/glarea.h
+++ b/src/meshlab/glarea.h
@@ -35,6 +35,7 @@
 
 #include <QTimer>
 #include <QTime>
+#include <QElapsedTimer>
 
 #include <common/plugins/interfaces/render_plugin.h>
 #include <common/plugins/interfaces/decorate_plugin.h>
@@ -177,7 +178,9 @@ public:
     bool isHelpVisible()      {return helpVisible;}
     bool isTrackBallVisible()		{return trackBallVisible;}
     bool isDefaultTrackBall()   {return activeDefaultTrackball;}
+    bool isStereopsisBobEnabled() const { return stereopsisBobEnabled; }
     void saveSnapshot();
+    void setStereopsisBobEnabled(bool enabled);
     void toggleHelpVisible()      {helpVisible = !helpVisible; update();}
   /*  void setBackFaceCulling(bool enabled);
     void setLight(bool state);
@@ -499,12 +502,21 @@ public slots:
     void updateRasterSetVisibilities();
 
 private slots:
+    void advanceStereopsisBob();
     void meshAdded(int index);
     void meshRemoved(int index);
 
 private:
     float cfps;
     float lastTime;
+    bool shouldStereopsisBob() const;
+    vcg::Point3f stereopsisBobEye(float cameraDist) const;
+    inline float stereopsisBobAmplitudeDegrees() const { return (glas.stereopsisBobAmount >= 0) ? glas.stereopsisBobAmount : 0.0f; }
+    inline float stereopsisBobFrequencyHz() const { return (glas.stereopsisBobSpeed >= 0) ? glas.stereopsisBobSpeed : 0.0f; }
+    inline int stereopsisBobFrameIntervalMs() const { return 16; }
+    bool stereopsisBobEnabled;
+    QTimer stereopsisBobTimer;
+    QElapsedTimer stereopsisBobClock;
 
     QImage snapBuffer;
     bool takeSnapTile;

--- a/src/meshlab/glarea_setting.cpp
+++ b/src/meshlab/glarea_setting.cpp
@@ -29,6 +29,8 @@ void GLAreaSetting::initGlobalParameterList(RichParameterList& defaultGlobalPara
 
 	defaultGlobalParamSet.addParam(RichBool(wheelDirectionParam(), false, "Wheel Direction", "If true, inverts the direction of the mouse wheel for zooming in/out in the MeshLab canvas."));
 	defaultGlobalParamSet.addParam(RichBool(showTrackballParam(), true, "Show Trackball", "If true, show the trackball on startup."));
+	defaultGlobalParamSet.addParam(RichFloat(stereopsisBobAmountParam(), 10.0, "Stereopsis Bob Amount", "Angular size of the circular bobbing motion, in degrees, around the nominal camera position."));
+	defaultGlobalParamSet.addParam(RichFloat(stereopsisBobSpeedParam(), 0.2f, "Stereopsis Bob Speed", "Speed of the circular bobbing motion, in cycles per second."));
 	defaultGlobalParamSet.addParam(RichInt(matrixDecimalPrecisionParam(), 2, "Rotation Matrix Precision", "Number of decimal values shown in the rotation matrix"));
 }
 
@@ -54,7 +56,13 @@ void GLAreaSetting::updateGlobalParameterSet( const RichParameterList& rps )
 	pointSmooth = rps.getBool(this->pointSmoothParam());
 	pointSize = rps.getFloat(this->pointSizeParam());
 	wheelDirection = rps.getBool(this->wheelDirectionParam());
-        startupShowTrackball = rps.getBool(showTrackballParam());
+	startupShowTrackball = rps.getBool(showTrackballParam());
+	stereopsisBobAmount = rps.getFloat(this->stereopsisBobAmountParam());
+	if (stereopsisBobAmount < 0)
+		stereopsisBobAmount = 0;
+	stereopsisBobSpeed = rps.getFloat(this->stereopsisBobSpeedParam());
+	if (stereopsisBobSpeed < 0)
+		stereopsisBobSpeed = 0;
 	matrixDecimalPrecision = rps.getInt(this->matrixDecimalPrecisionParam());
 	currentGlobalParamSet=&rps;
 }

--- a/src/meshlab/glarea_setting.h
+++ b/src/meshlab/glarea_setting.h
@@ -72,6 +72,10 @@ public:
 	inline static QString wheelDirectionParam() {return "MeshLab::Appearance::wheelDirection";}
 	bool startupShowTrackball;
 	inline static QString showTrackballParam() {return "MeshLab::Appearance::showTrackball";}
+	Scalarm stereopsisBobAmount;
+	inline static QString stereopsisBobAmountParam() {return "MeshLab::Appearance::stereopsisBobAmount";}
+	Scalarm stereopsisBobSpeed;
+	inline static QString stereopsisBobSpeedParam() {return "MeshLab::Appearance::stereopsisBobSpeed";}
 	int matrixDecimalPrecision;
 	inline static QString matrixDecimalPrecisionParam() {return "MeshLab::Appearance::matrixDecimalPrecision";}
 

--- a/src/meshlab/mainwindow.h
+++ b/src/meshlab/mainwindow.h
@@ -208,6 +208,7 @@ private slots:
 	void showToolbarFile();
 	void showInfoPane();
 	void showTrackBall();
+	void toggleStereopsisBob();
 	void resetTrackBall();
 	void showLayerDlg(bool visible);
 	void showRaster();
@@ -453,6 +454,7 @@ private:
 	QAction* showToolbarStandardAct;
 	QAction* showInfoPaneAct;
 	QAction* showTrackBallAct;
+	QAction* stereopsisBobAct;
 	QAction* resetTrackBallAct;
 	QAction* showLayerDlgAct;
 	QAction* showRasterAct;

--- a/src/meshlab/mainwindow_Init.cpp
+++ b/src/meshlab/mainwindow_Init.cpp
@@ -292,6 +292,13 @@ connectRenderModeActionList(rendlist);*/
 	showTrackBallAct->setShortcut(Qt::SHIFT + Qt::Key_H);
 	connect(showTrackBallAct, SIGNAL(triggered()), this, SLOT(showTrackBall()));
 
+	stereopsisBobAct = new QAction(tr("Stereopsis &Bob"), this);
+	stereopsisBobAct->setCheckable(true);
+	stereopsisBobAct->setShortcutContext(Qt::ApplicationShortcut);
+	stereopsisBobAct->setShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_B);
+	stereopsisBobAct->setToolTip(tr("Orbit the current view slightly left and right to add motion-based depth cues."));
+	connect(stereopsisBobAct, SIGNAL(triggered()), this, SLOT(toggleStereopsisBob()));
+
 	resetTrackBallAct = new QAction(tr("Reset &Trackball"), this);
 	resetTrackBallAct->setShortcutContext(Qt::ApplicationShortcut);
 #if defined(Q_OS_MAC)
@@ -609,6 +616,7 @@ void MainWindow::createMenus()
 	viewMenu->addAction(showRasterAct);
 	viewMenu->addSeparator();
 	viewMenu->addAction(showTrackBallAct);
+	viewMenu->addAction(stereopsisBobAct);
 	viewMenu->addAction(resetTrackBallAct);
 	viewMenu->addSeparator();
 	viewMenu->addAction(toggleOrthoAct);

--- a/src/meshlab/mainwindow_RunTime.cpp
+++ b/src/meshlab/mainwindow_RunTime.cpp
@@ -140,6 +140,7 @@ void MainWindow::updateWindowMenu()
 		trackballStepMenu = windowsMenu->addMenu(tr("Trackball step"));
 		foreach(QAction *ac, trackballStepGroupAct->actions())
 			trackballStepMenu->addAction(ac);
+		windowsMenu->addAction(stereopsisBobAct);
 		
 		// View From File act
 		windowsMenu->addAction(readViewFromFileAct);
@@ -340,6 +341,7 @@ void MainWindow::updateMenus()
 	fullScreenAct->setEnabled(activeDoc);
 	showLayerDlgAct->setEnabled(activeDoc);
 	showTrackBallAct->setEnabled(activeDoc);
+	stereopsisBobAct->setEnabled(activeDoc);
 	resetTrackBallAct->setEnabled(activeDoc);
 	showInfoPaneAct->setEnabled(activeDoc);
 	windowsMenu->setEnabled(activeDoc);
@@ -377,6 +379,7 @@ void MainWindow::updateMenus()
 		
 		showInfoPaneAct->setChecked(GLA()->infoAreaVisible);
 		showTrackBallAct->setChecked(GLA()->isTrackBallVisible());
+		stereopsisBobAct->setChecked(GLA()->isStereopsisBobEnabled());
 		
 		// Decorator Menu Checking and unChecking
 		// First uncheck and disable all the decorators
@@ -418,6 +421,7 @@ void MainWindow::updateMenus()
 	}
 	else
 	{
+		stereopsisBobAct->setChecked(false);
 		for (DecoratePlugin* dp : PM.decoratePluginIterator()){
 			for (QAction* a : dp->actions()){
 				a->setChecked(false);
@@ -2529,6 +2533,12 @@ void MainWindow::showTrackBall()
 {
 	if(GLA() != 0)
 		GLA()->showTrackBall(!GLA()->isTrackBallVisible());
+}
+
+void MainWindow::toggleStereopsisBob()
+{
+	if (GLA() != 0)
+		GLA()->setStereopsisBobEnabled(!GLA()->isStereopsisBobEnabled());
 }
 
 void MainWindow::resetTrackBall()


### PR DESCRIPTION
Closes #400 

Press "control shift b" to toggle on "stereopsis bob", which makes the camera move in a circle so that you can see depth on point clouds without manually jiggling the mouse. 

There are 2 settings controlling radius and speed of the bob. 

There are also options in View and Window to enable/disable.