### PR TITLE
Fix matrix multiplication order in point-based gluing

### DIFF
--- a/src/meshlabplugins/edit_align/edit_align.cpp
+++ b/src/meshlabplugins/edit_align/edit_align.cpp
@@ -285,7 +285,7 @@ void EditAlignPlugin::glueByPicking()
         ComputeRigidMatchMatrix(gluedPnt,freePnt,res);
 
     //md->mm()->cm.Tr=res;
-	currentNode()->tr() = currentNode()->tr() * res;
+	currentNode()->tr() = res * currentNode()->tr();
     QString buf;
     // for(size_t i=0;i<freePnt.size();++i)
     //		meshTree.cb(0,qUtf8Printable(buf.sprintf("%f %f %f -- %f %f %f \n",freePnt[i][0],freePnt[i][1],freePnt[i][2],gluedPnt[i][0],gluedPnt[i][1],gluedPnt[i][2])));


### PR DESCRIPTION
Closes #1651 


Let:
- $\mathbf{p}_{\text{local}}$ be a point in the local coordinate space of the free mesh.
- $T_{\text{old}}$ be the current transformation matrix of the free mesh (`currentNode()->tr()`).
- $`\mathbf{p}_{\text{global}} = T_{\text{old}} \cdot \mathbf{p}_{\text{local}}`$ be the point's current global position.
- $R$ be the alignment/registration transformation matrix (`res`) computed by `ComputeRigidMatchMatrix` or `ComputeSimilarityMatchMatrix`.

The registration algorithm finds a transformation $R$ that registers the picked points $`\mathbf{p}_{\text{free, global}}`$ to the glued points $`\mathbf{p}_{\text{glued, global}}`$, both of which are in global coordinates. Therefore, the registered global position is:
$`\mathbf{p}_{\text{global, new}} = R \cdot \mathbf{p}_{\text{global, old}}`$

Substituting the definition of $`\mathbf{p}_{\text{global}}`$:
$`\mathbf{p}_{\text{global, new}} = R \cdot (T_{\text{old}} \cdot \mathbf{p}_{\text{local}}) = (R \cdot T_{\text{old}}) \cdot \mathbf{p}_{\text{local}}`$

Then the new transformation matrix of the mesh must be:
$$T_{\text{new}} = R \cdot T_{\text{old}}$$
which is **pre-multiplication** (`res * currentNode()->tr()`).

