### PR TITLE
Preserve edge topology when exporting PLY meshes

### DIFF
--- a/src/meshlab/dialogs/save_mesh_attributes_dialog.cpp
+++ b/src/meshlab/dialogs/save_mesh_attributes_dialog.cpp
@@ -280,7 +280,10 @@ bool SaveMeshAttributesDialog::shouldBeChecked(int bit, int /*capabilityBits*/, 
 
 void SaveMeshAttributesDialog::updateMask()
 {
-	int newmask = 0;
+	// Edge connectivity is topology, not an optional per-element attribute, and
+	// therefore has no checkbox in this dialog. Preserve it when the exporter
+	// includes it in its default mask.
+	int newmask = defaultBits & vcg::tri::io::Mask::IOM_EDGEINDEX;
 
 	if( ui->check_iom_vertflags->isChecked()    ) { newmask |= vcg::tri::io::Mask::IOM_VERTFLAGS;}
 	if( ui->check_iom_vertcolor->isChecked()    ) { newmask |= vcg::tri::io::Mask::IOM_VERTCOLOR;}
@@ -319,4 +322,3 @@ void SaveMeshAttributesDialog::on_textureQualitySpinBox_valueChanged(int arg1)
 		ui->textureQualitySpinBox->setSuffix("");
 	}
 }
-

--- a/src/meshlabplugins/io_base/baseio.cpp
+++ b/src/meshlabplugins/io_base/baseio.cpp
@@ -668,7 +668,7 @@ void BaseMeshIOPlugin::saveProject(
 void BaseMeshIOPlugin::exportMaskCapability(const QString &format, int &capability, int &defaultBits) const
 {
 	if (format.toUpper() == tr("PLY")) {
-		capability = tri::io::ExporterPLY<CMeshO>::GetExportMaskCapability();
+		capability = tri::io::ExporterPLY<CMeshO>::GetExportMaskCapability() | tri::io::Mask::IOM_EDGEINDEX;
 		// For the default bits of the ply format disable flags and normals that usually are not useful.
 		defaultBits = capability;
 		defaultBits &= (~tri::io::Mask::IOM_FLAGS);


### PR DESCRIPTION
## Summary

- advertise edge-index support for PLY export
- preserve edge connectivity through the save-attributes dialog
- keep edge topology implicit because the dialog only exposes optional attributes

## Problem

When a PLY containing explicit edges is saved from MeshLab, the output contains the remaining vertices but omits the edge element. The PLY writer already supports edge serialization and compact endpoint remapping, but `IOM_EDGEINDEX` is absent from the PLY export capability mask. The save dialog also reconstructs the mask only from visible attribute checkboxes, so topology bits without a checkbox are discarded.

## Validation

- built the `meshlab` and `io_base` targets successfully
- loaded the built `io_base` plugin and verified that PLY capability and default masks contain `IOM_EDGEINDEX`
- round-tripped a synthetic line mesh after deleting a vertex and its incident edges; the reloaded PLY contained 2 vertices, 1 edge, and valid compacted endpoint indices
- manually verified that edited line PLY files retain their remaining lines after saving in MeshLab